### PR TITLE
Sightings integration

### DIFF
--- a/grails-app/domain/au/org/ala/ecodata/Activity.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/Activity.groovy
@@ -39,6 +39,7 @@ class Activity {
     Boolean assessment = false
     String siteId
     String projectId
+    String projectActivityId
     String description
     String type
     Date startDate
@@ -73,6 +74,7 @@ class Activity {
     static constraints = {
         siteId nullable: true
         projectId nullable: true
+        projectActivityId nullable: true
         description nullable: true
         startDate nullable: true
         endDate nullable: true

--- a/grails-app/domain/au/org/ala/ecodata/Record.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/Record.groovy
@@ -8,6 +8,7 @@ class Record {
 
     ObjectId id
     String projectId //ID of the project within ecodata
+    String projectActivityId
     String occurrenceID
     String userId
     String eventDate //should be a date in "yyyy-MM-dd" or "2014-11-24T04:55:48+11:00" format
@@ -17,21 +18,28 @@ class Record {
     Integer individualCount
     Date dateCreated
     Date lastUpdated
+    String outputId
+    String json
+    Integer outputItemId
 
     def beforeValidate() {
-        if(occurrenceID == null){
+        if (occurrenceID == null) {
             //mint an UUID
             occurrenceID = UUID.randomUUID().toString()
         }
     }
 
     static constraints = {
-        projectId nullable:true
-        eventDate nullable:true
-        decimalLatitude nullable:true
-        decimalLongitude nullable:true
+        projectId nullable: true
+        projectActivityId nullable: true
+        eventDate nullable: true
+        decimalLatitude nullable: true
+        decimalLongitude nullable: true
         userId nullable: true
         coordinateUncertaintyInMeters nullable: true
         individualCount nullable: true
+        outputId nullable: true
+        json nullable: true
+        outputItemId nullable: true
     }
 }

--- a/grails-app/services/au/org/ala/ecodata/ActivityService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ActivityService.groovy
@@ -173,7 +173,7 @@ class ActivityService {
         if (activity) {
             // do updates for each attached output
             props.outputs?.each { output ->
-                if (output.outputId) {
+                if (output.outputId && output.outputId != "null") {
                     // update
                     log.debug "Updating output ${output.name}"
                     def result = outputService.update(output, output.outputId)

--- a/grails-app/services/au/org/ala/ecodata/ActivityService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ActivityService.groovy
@@ -10,7 +10,11 @@ class ActivityService {
     static final FLAT = 'flat'
     static final SITE = 'site'
 
-    def grailsApplication, outputService, commonService, documentService, siteService
+    def grailsApplication
+    OutputService outputService
+    CommonService commonService
+    DocumentService documentService
+    SiteService siteService
 
     def get(id, levelOfDetail = []) {
         def o = Activity.findByActivityIdAndStatus(id, ACTIVE)
@@ -103,25 +107,28 @@ class ActivityService {
      * @param props the activity properties
      * @return json status
      */
-    def create(props) {
-        def o = new Activity(siteId: props.siteId, activityId: Identifiers.getNew(true,''))
+    def create(Map props) {
+        Activity activity = new Activity(siteId: props.siteId, activityId: Identifiers.getNew(true, ''))
         try {
-            o.save(failOnError: true)
+            activity.save(failOnError: true)
 
             props.remove('id')
-            def outputs = props.remove('outputs')
-            commonService.updateProperties(o, props)
+            List outputs = props.remove('outputs')
+            commonService.updateProperties(activity, props)
+
             // If outputs were supplied, update those separately.
             if (outputs) {
-                update(outputs:outputs, o.activityId)
+                update(outputs: outputs, activity.activityId)
             }
-            return [status:'ok',activityId:o.activityId]
+            
+            return [status: 'ok', activityId: activity.activityId]
         } catch (Exception e) {
             // clear session to avoid exception when GORM tries to autoflush the changes
             Activity.withSession { session -> session.clear() }
             def error = "Error creating activity for site ${props.siteId} - ${e.message}"
-            log.error error
-            return [status:'error',error:error]
+            log.error error, e
+            
+            return [status: 'error', error: error]
         }
     }
 
@@ -161,9 +168,9 @@ class ActivityService {
      */
     def update(props, id) {
         //log.debug "props = ${props}"
-        def a = Activity.findByActivityId(id)
+        def activity = Activity.findByActivityId(id)
         def errors = []
-        if (a) {
+        if (activity) {
             // do updates for each attached output
             props.outputs?.each { output ->
                 if (output.outputId) {
@@ -188,7 +195,7 @@ class ActivityService {
             if (props.activityId) {
                 try {
                     props.remove('outputs') // get rid of the hitchhiking outputs before updating the activity
-                    commonService.updateProperties(a, props)
+                    commonService.updateProperties(activity, props)
                 } catch (Exception e) {
                     Activity.withSession { session -> session.clear() }
                     def error = "Error updating Activity ${id} - ${e.message}"

--- a/grails-app/services/au/org/ala/ecodata/OutputService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/OutputService.groovy
@@ -33,15 +33,20 @@ class OutputService {
         Output.findAllByActivityIdAndNameAndStatus(id, name, ACTIVE).collect { toMap(it, levelOfDetail) }
     }
 
-    def delete(String id, destroy) {
-        def a = Output.findByOutputId(id)
-        if (a) {
+    def delete(String id, boolean destroy) {
+        def output = Output.findByOutputId(id)
+        if (output) {
             if (destroy) {
-                a.delete()
+                output.delete()
             } else {
-                a.status = 'deleted'
-                a.save(flush: true)
+                output.status = 'deleted'
+                output.save(flush: true)
             }
+
+            Record.findAllByOutputId(id)?.each {
+                it.delete()
+            }
+
             return [status:'ok']
         } else {
             return [status:'error', error:'No such id']
@@ -144,7 +149,7 @@ class OutputService {
             try {
                 getCommonService().updateProperties(output, props)
 
-                List<Record> records = Record.findByOutputId(outputId)
+                List<Record> records = Record.findAllByOutputId(outputId)
 
                 if (records) {
                     records.each {

--- a/models/activities-model.json
+++ b/models/activities-model.json
@@ -3380,6 +3380,11 @@
             "template": "gaSiteVisitDetails",
             "scores": [],
             "name": "Site Visit Details"
+        },
+        {
+          "template": "singleSighting",
+          "scores": [],
+          "name": "Single Sighting"
         }
     ],
     "activities": [
@@ -3972,6 +3977,12 @@
             "supportsSites": false,
             "type": "Report",
             "category": "Programme Reporting"
+        },
+        {
+          "name": "Single Sighting",
+          "type": "Activity",
+          "category": "Assessment & monitoring",
+          "outputs": ["Single Sighting"]
         }
     ]
 }

--- a/models/activities-model.json
+++ b/models/activities-model.json
@@ -3385,6 +3385,11 @@
           "template": "singleSighting",
           "scores": [],
           "name": "Single Sighting"
+        },
+        {
+          "template": "multipleSightings",
+          "scores": [],
+          "name": "Multiple Sightings"
         }
     ],
     "activities": [
@@ -3983,6 +3988,12 @@
           "type": "Activity",
           "category": "Assessment & monitoring",
           "outputs": ["Single Sighting"]
+        },
+        {
+          "name": "Multiple Sightings",
+          "type": "Activity",
+          "category": "Assessment & monitoring",
+          "outputs": ["Multiple Sightings"]
         }
     ]
 }

--- a/models/multipleSightings/dataModel.json
+++ b/models/multipleSightings/dataModel.json
@@ -1,0 +1,88 @@
+{
+  "modelName": "Multiple Sightings",
+  "dataModel": [
+    {
+      "dataType": "masterDetail",
+      "name": "multipleSightings",
+      "record": "true",
+      "master": {
+        "dataType": "list",
+        "name": "sightings",
+        "columns": [
+          {
+            "title": "Name",
+            "source": "scientificName",
+            "width": "35%"
+          },
+          {
+            "title": "Locality",
+            "source": "locality",
+            "width": "35%"
+          },
+          {
+            "title": "Latitude",
+            "source": "decimalLatitude",
+            "width": "10%"
+          },
+          {
+            "title": "Longitude",
+            "source": "decimalLongitude",
+            "width": "10%"
+          }
+        ]
+      },
+      "detail": {
+        "dataType": "singleSighting",
+        "description": "Record a sighting",
+        "name": "sighting"
+      }
+    }
+  ],
+  "viewModel": [
+    {
+      "source": "multipleSightings",
+      "type": "masterDetail",
+      "master": {
+        "type": "table",
+        "columns": [
+          {
+            "title": "Name",
+            "type": "readonlyText",
+            "source": "scientificName",
+            "width": "35%"
+          },
+          {
+            "title": "Locality",
+            "type": "readonlyText",
+            "source": "locality",
+            "width": "35%"
+          },
+          {
+            "title": "Latitude",
+            "type": "readonlyText",
+            "source": "decimalLatitude",
+            "width": "10%"
+          },
+          {
+            "title": "Longitude",
+            "type": "readonlyText",
+            "source": "decimalLongitude",
+            "width": "10%"
+          }
+        ]
+      },
+      "detail": [
+        {
+          "type": "template",
+          "source": "/submitSighting/submitSightingResources",
+          "plugin": "biocollectSightings"
+        },
+        {
+          "type": "template",
+          "source": "/submitSighting/submitSighting",
+          "plugin": "biocollectSightings"
+        }
+      ]
+    }
+  ]
+}

--- a/models/multipleSightings/dataModel.json
+++ b/models/multipleSightings/dataModel.json
@@ -10,7 +10,7 @@
         "name": "sightings",
         "columns": [
           {
-            "title": "Name",
+            "title": "Scientific Name",
             "source": "scientificName",
             "width": "35%"
           },
@@ -46,7 +46,7 @@
         "type": "table",
         "columns": [
           {
-            "title": "Name",
+            "title": "Scientific Name",
             "type": "readonlyText",
             "source": "scientificName",
             "width": "35%"

--- a/models/singleSighting/dataModel.json
+++ b/models/singleSighting/dataModel.json
@@ -2,6 +2,7 @@
   "modelName": "Single Sighting",
   "dataModel": [
     {
+      "name": "singleSighting",
       "dataType": "singleSighting",
       "record": "true"
     }

--- a/models/singleSighting/dataModel.json
+++ b/models/singleSighting/dataModel.json
@@ -1,0 +1,18 @@
+{
+  "modelName": "Single Sighting",
+  "dataModel": [
+    {
+      "dataType": "singleSighting"
+    }
+  ],
+  "viewModel": [
+    {
+      "items": [
+        {
+          "type": "singleSighting"
+        }
+      ],
+      "type": "row"
+    }
+  ]
+}

--- a/models/singleSighting/dataModel.json
+++ b/models/singleSighting/dataModel.json
@@ -2,7 +2,8 @@
   "modelName": "Single Sighting",
   "dataModel": [
     {
-      "dataType": "singleSighting"
+      "dataType": "singleSighting",
+      "record": "true"
     }
   ],
   "viewModel": [

--- a/models/singleSighting/dataModel.json
+++ b/models/singleSighting/dataModel.json
@@ -9,12 +9,14 @@
   ],
   "viewModel": [
     {
-      "items": [
-        {
-          "type": "singleSighting"
-        }
-      ],
-      "type": "row"
+      "type": "template",
+      "source": "/submitSighting/submitSightingResources",
+      "plugin": "biocollectSightings"
+    },
+    {
+      "type": "template",
+      "source": "/submitSighting/submitSighting",
+      "plugin": "biocollectSightings"
     }
   ]
 }

--- a/src/groovy/au/org/ala/ecodata/converter/GenericConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/GenericConverter.groovy
@@ -1,11 +1,10 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.JSON
 
 class GenericConverter implements RecordConverter {
 
-    List<Record> convert(Map data, Map metadata = [:]) {
-        [new Record(json: (data as JSON).toString())]
+    List<Map> convert(Map data, Map metadata = [:]) {
+        [[json: (data.data as JSON).toString(), userId: data.data.userId]]
     }
 }

--- a/src/groovy/au/org/ala/ecodata/converter/GenericConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/GenericConverter.groovy
@@ -1,0 +1,11 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.JSON
+
+class GenericConverter implements RecordConverter {
+
+    List<Record> convert(Map data, Map metadata = [:]) {
+        [new Record(json: (data as JSON).toString())]
+    }
+}

--- a/src/groovy/au/org/ala/ecodata/converter/ListConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/ListConverter.groovy
@@ -1,13 +1,12 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.JSON
 
 class ListConverter implements RecordConverter {
 
     @Override
-    List<Record> convert(Map data, Map outputMetadata = [:]) {
-        List<Record> records = []
+    List<Map> convert(Map data, Map outputMetadata = [:]) {
+        List<Map> records = []
 
         Map dwcMappings = [:]
         outputMetadata.columns.each {
@@ -17,7 +16,8 @@ class ListConverter implements RecordConverter {
         }
 
         data.data[outputMetadata.name].eachWithIndex { it, index ->
-            Record record = new Record(json: (it as JSON).toString())
+            Map record = [:]
+            record.json = (it as JSON).toString()
 
             if (dwcMappings.containsKey("individualCount")) {
                 record.individualCount = Integer.parseInt(it[dwcMappings["individualCount"]])

--- a/src/groovy/au/org/ala/ecodata/converter/ListConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/ListConverter.groovy
@@ -1,0 +1,44 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.JSON
+
+class ListConverter implements RecordConverter {
+
+    @Override
+    List<Record> convert(Map data, Map outputMetadata = [:]) {
+        List<Record> records = []
+
+        Map dwcMappings = [:]
+        outputMetadata.columns.each {
+            if (it.containsKey(DWC_ATTRIBUTE_NAME)) {
+                dwcMappings[it.dwcAttribute] = it.name
+            }
+        }
+
+        data.data[outputMetadata.name].eachWithIndex { it, index ->
+            Record record = new Record(json: (it as JSON).toString())
+
+            if (dwcMappings.containsKey("individualCount")) {
+                record.individualCount = Integer.parseInt(it[dwcMappings["individualCount"]])
+            }
+
+            if (dwcMappings.containsKey("decimalLatitude")) {
+                record.decimalLatitude = Double.parseDouble(it[dwcMappings["decimalLatitude"]])
+            }
+            if (dwcMappings.containsKey("decimalLongitude")) {
+                record.decimalLongitude = Double.parseDouble(it[dwcMappings["decimalLongitude"]])
+            }
+
+            if (dwcMappings.containsKey("creator")) {
+                record.userId = it[dwcMappings["creator"]]
+            }
+
+            record.outputItemId = index
+
+            records << record
+        }
+
+        records
+    }
+}

--- a/src/groovy/au/org/ala/ecodata/converter/MasterDetailConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/MasterDetailConverter.groovy
@@ -1,0 +1,20 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+
+class MasterDetailConverter implements RecordConverter {
+
+    @Override
+    List<Record> convert(Map data, Map outputMetadata = [:]) {
+        // delegate the conversion to a specific converter for the DETAIL portion of the master/detail
+        RecordConverter converter = RecordConverterFactory.getConverter(outputMetadata.detail.dataType)
+
+        List<Record> records = []
+
+        data.data[outputMetadata.name].each {
+            records.addAll converter.convert([data: it], outputMetadata.detail as Map)
+        }
+
+        records
+    }
+}

--- a/src/groovy/au/org/ala/ecodata/converter/MasterDetailConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/MasterDetailConverter.groovy
@@ -1,15 +1,13 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
-
 class MasterDetailConverter implements RecordConverter {
 
     @Override
-    List<Record> convert(Map data, Map outputMetadata = [:]) {
+    List<Map> convert(Map data, Map outputMetadata = [:]) {
         // delegate the conversion to a specific converter for the DETAIL portion of the master/detail
         RecordConverter converter = RecordConverterFactory.getConverter(outputMetadata.detail.dataType)
 
-        List<Record> records = []
+        List<Map> records = []
 
         data.data[outputMetadata.name].each {
             records.addAll converter.convert([data: it], outputMetadata.detail as Map)

--- a/src/groovy/au/org/ala/ecodata/converter/RecordConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/RecordConverter.groovy
@@ -1,0 +1,20 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+
+/**
+ * Converts an Output's data model into one or more Records.
+ *
+ * To trigger a conversion, the data model in dataModel.json must have the 'record: true' attribute.
+ *
+ * Individual fields from the data can be mapped to specific Record attributes by adding a 'dwcAttribute' attribute to
+ * an item in the data model. NOTE: the dwcAttribute value should be a standard Darwin Core Archive Term, even if the
+ * target Record attribute is different (the converter is responsible for mapping one to the other).
+ */
+interface RecordConverter {
+    String DWC_ATTRIBUTE_NAME = "dwcAttribute"
+
+    List<Record> convert(Map data)
+
+    List<Record> convert(Map data, Map outputMetadata)
+}

--- a/src/groovy/au/org/ala/ecodata/converter/RecordConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/RecordConverter.groovy
@@ -1,7 +1,5 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
-
 /**
  * Converts an Output's data model into one or more Records.
  *
@@ -14,7 +12,7 @@ import au.org.ala.ecodata.Record
 interface RecordConverter {
     String DWC_ATTRIBUTE_NAME = "dwcAttribute"
 
-    List<Record> convert(Map data)
+    List<Map> convert(Map data)
 
-    List<Record> convert(Map data, Map outputMetadata)
+    List<Map> convert(Map data, Map outputMetadata)
 }

--- a/src/groovy/au/org/ala/ecodata/converter/RecordConverterFactory.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/RecordConverterFactory.groovy
@@ -1,0 +1,23 @@
+package au.org.ala.ecodata.converter
+
+import groovy.util.logging.Log4j
+import org.apache.commons.lang.StringUtils
+
+@Log4j
+class RecordConverterFactory {
+
+    static RecordConverter getConverter(String outputDataType) {
+        String packageName = RecordConverter.class.package.getName()
+        String className = "${StringUtils.capitalize(outputDataType).replaceAll("[ _\\-]", "")}Converter"
+
+        RecordConverter converter
+        try {
+            converter = Class.forName("${packageName}.${className}")?.newInstance()
+        } catch (ClassNotFoundException e) {
+            log.debug "No specific converter found for output data type ${outputDataType} with class name ${packageName}.${className}, using generic converter"
+            converter = new GenericConverter()
+        }
+
+        converter
+    }
+}

--- a/src/groovy/au/org/ala/ecodata/converter/RecordConverterFactory.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/RecordConverterFactory.groovy
@@ -14,7 +14,7 @@ class RecordConverterFactory {
         try {
             converter = Class.forName("${packageName}.${className}")?.newInstance()
         } catch (ClassNotFoundException e) {
-            log.debug "No specific converter found for output data type ${outputDataType} with class name ${packageName}.${className}, using generic converter"
+            log.warn "No specific converter found for output data type ${outputDataType} with class name ${packageName}.${className}, using generic converter"
             converter = new GenericConverter()
         }
 

--- a/src/groovy/au/org/ala/ecodata/converter/SingleSightingConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/SingleSightingConverter.groovy
@@ -1,0 +1,21 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.JSON
+
+class SingleSightingConverter implements RecordConverter {
+    @Override
+    List<Record> convert(Map data, Map outputMetadata = [:]) {
+        Record record = new Record()
+
+        record.decimalLatitude = Double.parseDouble(data.data.decimalLatitude)
+        record.decimalLongitude = Double.parseDouble(data.data.decimalLongitude)
+        record.eventDate = data.data.eventDate
+        record.individualCount = Integer.parseInt(data.data.individualCount)
+        record.userId = data.data.userId
+
+        record.json = (data as JSON).toString()
+
+        [record]
+    }
+}

--- a/src/groovy/au/org/ala/ecodata/converter/SingleSightingConverter.groovy
+++ b/src/groovy/au/org/ala/ecodata/converter/SingleSightingConverter.groovy
@@ -1,18 +1,18 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.JSON
 
 class SingleSightingConverter implements RecordConverter {
     @Override
-    List<Record> convert(Map data, Map outputMetadata = [:]) {
-        Record record = new Record()
+    List<Map> convert(Map data, Map outputMetadata = [:]) {
+        Map record = [:]
 
         record.decimalLatitude = Double.parseDouble(data.data.decimalLatitude)
         record.decimalLongitude = Double.parseDouble(data.data.decimalLongitude)
         record.eventDate = data.data.eventDate
         record.individualCount = Integer.parseInt(data.data.individualCount)
         record.userId = data.data.userId
+        record.multimedia = data.data.multimedia
 
         record.json = (data as JSON).toString()
 

--- a/test/unit/au/org/ala/ecodata/converter/GenericConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/GenericConverterSpec.groovy
@@ -1,6 +1,5 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.JSON
 import spock.lang.Specification
 
@@ -8,13 +7,14 @@ class GenericConverterSpec extends Specification {
 
     def "convert should return a single record with the json attribute set to the JSON representation of the source data"() {
         setup:
-        Map data = [field1: "val1", field2: "val2"]
+        Map data = [data: [field1: "val1", field2: "val2", userId: "user1"]]
 
         when:
-        List<Record> result = new GenericConverter().convert(data)
+        List<Map> result = new GenericConverter().convert(data)
 
         then:
         result.size() == 1
-        result[0].json == (data as JSON).toString()
+        result[0].json == (data.data as JSON).toString()
+        result[0].userId == "user1"
     }
 }

--- a/test/unit/au/org/ala/ecodata/converter/GenericConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/GenericConverterSpec.groovy
@@ -1,0 +1,20 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.JSON
+import spock.lang.Specification
+
+class GenericConverterSpec extends Specification {
+
+    def "convert should return a single record with the json attribute set to the JSON representation of the source data"() {
+        setup:
+        Map data = [field1: "val1", field2: "val2"]
+
+        when:
+        List<Record> result = new GenericConverter().convert(data)
+
+        then:
+        result.size() == 1
+        result[0].json == (data as JSON).toString()
+    }
+}

--- a/test/unit/au/org/ala/ecodata/converter/ListConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/ListConverterSpec.groovy
@@ -1,0 +1,96 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.groovy.JsonSlurper
+import spock.lang.Specification
+
+class ListConverterSpec extends Specification {
+    def "convert should create records for each list item in the output data model with the json attribute set to the list item"() {
+        setup:
+        Map metadata = [
+                record  : "true",
+                name    : "actions",
+                dataType: "list",
+                columns : [
+                        [
+                                name: "col1"
+                        ]
+                ]
+        ]
+
+        String col1 = """{"col1": "action1"}"""
+        String col2 = """{"col1": "action2"}"""
+        String data = """{
+            "activityId": "activity1",
+            "name": "a",
+            "data": {
+                    "actions": [
+                        ${col1},
+                        ${col2}
+                    ]
+            }
+        }"""
+
+        when:
+        List<Record> result = new ListConverter().convert(new JsonSlurper().parseText(data), metadata)
+
+        then:
+        result.size() == 2
+        result[0].json.replaceAll("\\s", "") == col1.replaceAll("\\s", "")
+        result[0].outputItemId == 0
+        result[1].json.replaceAll("\\s", "") == col2.replaceAll("\\s", "")
+        result[1].outputItemId == 1
+    }
+
+    def "convert should extract Record attributes from the dwcAttribute of each item in the data model"() {
+        setup:
+        Map metadata = [
+                record  : "true",
+                name    : "actions",
+                dataType: "list",
+                columns : [
+                        [
+                                name        : "col1",
+                                dwcAttribute: "individualCount"
+                        ],
+                        [
+                                name        : "col2",
+                                dwcAttribute: "decimalLatitude"
+                        ],
+                        [
+                                name        : "col3",
+                                dwcAttribute: "decimalLongitude"
+                        ]
+                ]
+        ]
+
+        String col1 = """{"col1": "1", "col2": "1.1", "col3": "1.11"}"""
+        String col2 = """{"col1": "2", "col2": "2.1", "col3": "2.11"}"""
+        String data = """{
+            "activityId": "activity1",
+            "name": "a",
+            "data": {
+                    "actions": [
+                        ${col1},
+                        ${col2}
+                    ]
+            }
+        }"""
+
+        when:
+        List<Record> result = new ListConverter().convert(new JsonSlurper().parseText(data), metadata)
+
+        then:
+        result.size() == 2
+        result[0].json.replaceAll("\\s", "") == col1.replaceAll("\\s", "")
+        result[0].outputItemId == 0
+        result[0].individualCount == 1
+        result[0].decimalLatitude == 1.1
+        result[0].decimalLongitude == 1.11
+        result[1].json.replaceAll("\\s", "") == col2.replaceAll("\\s", "")
+        result[1].outputItemId == 1
+        result[1].individualCount == 2
+        result[1].decimalLatitude == 2.1
+        result[1].decimalLongitude == 2.11
+    }
+}

--- a/test/unit/au/org/ala/ecodata/converter/ListConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/ListConverterSpec.groovy
@@ -1,6 +1,5 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.groovy.JsonSlurper
 import spock.lang.Specification
 
@@ -32,7 +31,7 @@ class ListConverterSpec extends Specification {
         }"""
 
         when:
-        List<Record> result = new ListConverter().convert(new JsonSlurper().parseText(data), metadata)
+        List<Map> result = new ListConverter().convert(new JsonSlurper().parseText(data), metadata)
 
         then:
         result.size() == 2
@@ -78,7 +77,7 @@ class ListConverterSpec extends Specification {
         }"""
 
         when:
-        List<Record> result = new ListConverter().convert(new JsonSlurper().parseText(data), metadata)
+        List<Map> result = new ListConverter().convert(new JsonSlurper().parseText(data), metadata)
 
         then:
         result.size() == 2

--- a/test/unit/au/org/ala/ecodata/converter/MasterDetailConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/MasterDetailConverterSpec.groovy
@@ -1,0 +1,49 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.groovy.JsonSlurper
+import spock.lang.Specification
+
+class MasterDetailConverterSpec extends Specification {
+
+    def "should delegate the conversion to the appropriate converter for the detail data"() {
+        setup:
+        String data = """{
+                      "activityId": "activity1",
+                      "name": "Multiple Sightings",
+                      "data": {
+                        "multipleSightings": [
+                          {
+                            "userId": "user1",
+                            "individualCount": "1",
+                            "decimalLatitude": "2.1",
+                            "decimalLongitude": "3.1"
+                          },
+                          {
+                            "userId": "user11",
+                            "individualCount": "11",
+                            "decimalLatitude": "12.1",
+                            "decimalLongitude": "13.1"
+                          }
+                        ]
+                      }
+                    }"""
+
+        Map metadata = [name: "multipleSightings", master: [:], detail: [dataType: "singleSighting"]]
+
+        when:
+        List<Record> result = new MasterDetailConverter().convert(new JsonSlurper().parseText(data), metadata)
+
+        then:
+        result.size() == 2
+        result[0].individualCount == 1
+        result[0].decimalLatitude == 2.1
+        result[0].decimalLongitude == 3.1
+        result[0].userId == "user1"
+
+        result[1].individualCount == 11
+        result[1].decimalLatitude == 12.1
+        result[1].decimalLongitude == 13.1
+        result[1].userId == "user11"
+    }
+}

--- a/test/unit/au/org/ala/ecodata/converter/MasterDetailConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/MasterDetailConverterSpec.groovy
@@ -1,6 +1,5 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.groovy.JsonSlurper
 import spock.lang.Specification
 
@@ -32,7 +31,7 @@ class MasterDetailConverterSpec extends Specification {
         Map metadata = [name: "multipleSightings", master: [:], detail: [dataType: "singleSighting"]]
 
         when:
-        List<Record> result = new MasterDetailConverter().convert(new JsonSlurper().parseText(data), metadata)
+        List<Map> result = new MasterDetailConverter().convert(new JsonSlurper().parseText(data), metadata)
 
         then:
         result.size() == 2

--- a/test/unit/au/org/ala/ecodata/converter/RecordConverterFactorySpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/RecordConverterFactorySpec.groovy
@@ -1,0 +1,30 @@
+package au.org.ala.ecodata.converter
+
+import spock.lang.Specification
+
+class RecordConverterFactorySpec extends Specification {
+
+    def "factory should return a SingleSightingConverter if given a data type of 'singleSighting'"() {
+        when:
+        RecordConverter converter = RecordConverterFactory.getConverter("singleSighting")
+
+        then:
+        converter instanceof SingleSightingConverter
+    }
+
+    def "factory should return a ListConverter if given a data type of 'list'"() {
+        when:
+        RecordConverter converter = RecordConverterFactory.getConverter("list")
+
+        then:
+        converter instanceof ListConverter
+    }
+
+    def "factory should return a GenericConverter if given an unrecognised data type"() {
+        when:
+        RecordConverter converter = RecordConverterFactory.getConverter("something")
+
+        then:
+        converter instanceof GenericConverter
+    }
+}

--- a/test/unit/au/org/ala/ecodata/converter/SightingConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/SightingConverterSpec.groovy
@@ -1,6 +1,5 @@
 package au.org.ala.ecodata.converter
 
-import au.org.ala.ecodata.Record
 import net.sf.json.groovy.JsonSlurper
 import spock.lang.Specification
 
@@ -19,7 +18,7 @@ class SightingConverterSpec extends Specification {
         }"""
 
         when:
-        List<Record> result = new SingleSightingConverter().convert(new JsonSlurper().parseText(data))
+        List<Map> result = new SingleSightingConverter().convert(new JsonSlurper().parseText(data))
 
         then:
         result.size() == 1

--- a/test/unit/au/org/ala/ecodata/converter/SightingConverterSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/converter/SightingConverterSpec.groovy
@@ -1,0 +1,32 @@
+package au.org.ala.ecodata.converter
+
+import au.org.ala.ecodata.Record
+import net.sf.json.groovy.JsonSlurper
+import spock.lang.Specification
+
+class SightingConverterSpec extends Specification {
+    def "convert should create a single record with the relevant fields populated"() {
+        setup:
+        String data = """{
+            "activityId": "activity1",
+            "name": "Single Sighting",
+            "data": {
+                    "userId"          : "user1",
+                    "individualCount" : "1",
+                    "decimalLatitude" : "2.1",
+                    "decimalLongitude": "3.1"
+            }
+        }"""
+
+        when:
+        List<Record> result = new SingleSightingConverter().convert(new JsonSlurper().parseText(data))
+
+        then:
+        result.size() == 1
+        result[0].json.replaceAll("\\s", "") == data.replaceAll("\\s", "")
+        result[0].individualCount == 1
+        result[0].decimalLatitude == 2.1
+        result[0].decimalLongitude == 3.1
+        result[0].userId == "user1"
+    }
+}

--- a/test/unit/au/org/ala/ecodata/metadata/OutputServiceSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/metadata/OutputServiceSpec.groovy
@@ -1,0 +1,94 @@
+package au.org.ala.ecodata.metadata
+
+import au.org.ala.ecodata.Activity
+import au.org.ala.ecodata.CommonService
+import au.org.ala.ecodata.MetadataService
+import au.org.ala.ecodata.Output
+import au.org.ala.ecodata.OutputService
+import au.org.ala.ecodata.Record
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import net.sf.json.groovy.JsonSlurper
+import spock.lang.Specification
+
+@TestFor(OutputService)
+@Mock([Activity, Output, Record])
+class OutputServiceSpec extends Specification {
+
+    OutputService service
+    MetadataService mockMetadataService
+
+    def setup() {
+        service = new OutputService()
+        mockMetadataService = Mock(MetadataService)
+        service.metadataService = mockMetadataService
+        service.grailsApplication = [mainContext: [commonService: Mock(CommonService)]]
+    }
+
+    def "create output should create a record if the output data model has record = true"() {
+        setup:
+        String activityId = 'activity1'
+        Activity activity = new Activity(activityId: activityId, type: 'Test', description: 'A test activity')
+        activity.save(flush: true, failOnError: true)
+        mockMetadataService.getOutputDataModelByName(_) >> [modelName: "Single Sighting",
+                                                            dataModel: [[record: "true", dataType: "singleSighting"]]]
+
+        when:
+        def request = """{
+            "activityId": "activity1",
+            "name": "Single Sighting",
+            "data": {
+                    "userId"          : "10598",
+                    "individualCount" : "3",
+                    "decimalLatitude" : "-31.203404950917385",
+                    "decimalLongitude": "146.95312499999997"
+            }
+        }"""
+
+        Map response = service.create(new JsonSlurper().parseText(request))
+
+        then:
+        println response
+        response.status != "error"
+        Output.count() == 1
+        Record.count() == 1
+    }
+
+    def "create output should create records for each list item if the output data model has record = true and data type = list"() {
+        setup:
+        String activityId = 'activity1'
+        Activity activity = new Activity(activityId: activityId, type: 'Test', description: 'A test activity')
+        activity.save(flush: true, failOnError: true)
+        mockMetadataService.getOutputDataModelByName(_) >> [modelName: "Model 1",
+                                                            dataModel: [
+                                                                    [
+                                                                            record: "true",
+                                                                            name: "actions",
+                                                                            dataType: "list",
+                                                                    columns: [
+                                                                            [
+                                                                                    name: "col1"
+                                                                            ]
+                                                                    ]]]]
+
+        when:
+        def request = """{
+            "activityId": "activity1",
+            "name": "Something",
+            "data": {
+                    "actions": [
+                        {"col1": "action1"},
+                        {"col1": "action2"}
+                    ]
+            }
+        }"""
+
+        Map response = service.create(new JsonSlurper().parseText(request))
+
+        then:
+        println response
+        response.status != "error"
+        Output.count() == 1
+        Record.count() == 2
+    }
+}

--- a/test/unit/au/org/ala/ecodata/metadata/OutputServiceSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/metadata/OutputServiceSpec.groovy
@@ -6,6 +6,7 @@ import au.org.ala.ecodata.MetadataService
 import au.org.ala.ecodata.Output
 import au.org.ala.ecodata.OutputService
 import au.org.ala.ecodata.Record
+import au.org.ala.ecodata.RecordService
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import net.sf.json.groovy.JsonSlurper
@@ -17,11 +18,14 @@ class OutputServiceSpec extends Specification {
 
     OutputService service
     MetadataService mockMetadataService
+    RecordService mockRecordService
 
     def setup() {
         service = new OutputService()
         mockMetadataService = Mock(MetadataService)
+        mockRecordService = Mock(RecordService)
         service.metadataService = mockMetadataService
+        service.recordService = mockRecordService
         service.grailsApplication = [mainContext: [commonService: Mock(CommonService)]]
     }
 
@@ -32,6 +36,7 @@ class OutputServiceSpec extends Specification {
         activity.save(flush: true, failOnError: true)
         mockMetadataService.getOutputDataModelByName(_) >> [modelName: "Single Sighting",
                                                             dataModel: [[record: "true", dataType: "singleSighting"]]]
+        mockRecordService.createRecord(_) >> {new Record().save(flush:true)}
 
         when:
         def request = """{
@@ -70,6 +75,7 @@ class OutputServiceSpec extends Specification {
                                                                                     name: "col1"
                                                                             ]
                                                                     ]]]]
+        mockRecordService.createRecord(_) >> {new Record().save(flush:true)}
 
         when:
         def request = """{


### PR DESCRIPTION
Adds support for single and multiple sightings outputs/activities,
Adds support for creating Records from Output:
- add the 'record: true' attribute to your output's data model
- add "dwcAttribute: ''" attribute to individual fields within the data model (e.g. to columns in a list data model) to map them to Darwin Core terms.
- create a dedicated implementation of RecordConverter if necessary for your model's data type. 