### PR TITLE
Bumped asset-pipeline version down to 1.9.9 because of what appears t…

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -67,7 +67,8 @@ grails.project.dependency.resolution = {
 
     plugins {
         runtime ":jquery:1.11.1"
-        compile ":asset-pipeline:2.13.1"
+        compile ":asset-pipeline:1.9.9" // 2.13 has issues with java7, possibly there is a middle ground between 1.9.9 and 2.13
+
         // Uncomment these to enable additional asset-pipeline capabilities
         //compile ":sass-asset-pipeline:2.13.1"
         //compile ":less-asset-pipeline:2.13.1"


### PR DESCRIPTION
…o be a java7 incompatibility.