### PR TITLE
Fix a couple of instances of boolean parsing

### DIFF
--- a/grails-app/controllers/au/org/ala/ecodata/ActivityController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/ActivityController.groovy
@@ -32,7 +32,7 @@ class ActivityController {
         def detail = params.view == SCORES ? [SCORES] : []
         if (!id) {
 
-            def list = activityService.getAll(params.includeDeleted as boolean, params.view)
+            def list = activityService.getAll(params.boolean('includeDeleted'), params.view)
             list.sort {it.name}
             //log.debug list
             asJson([list: list])

--- a/grails-app/controllers/au/org/ala/ecodata/CommentController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/CommentController.groovy
@@ -92,7 +92,7 @@ class CommentController {
             response.sendError(SC_BAD_REQUEST, 'Missing text');
         } else {
             Map result
-            json.isALAAdmin = (json.isALAAdmin?:false) as Boolean;
+            json.isALAAdmin = (json?.isALAAdmin != null ? json?.isALAAdmin?.toString()?.toBoolean() : false)
             Comment comment = commentService.update(json);
             if(comment){
                 if ((comment.userId == json.userId) || json.isALAAdmin) {
@@ -120,7 +120,7 @@ class CommentController {
         if (!params.id) {
             response.sendError(SC_BAD_REQUEST, "Missing id");
         } else {
-            params.isALAAdmin = (params.isALAAdmin?:false) as Boolean;
+            params.isALAAdmin = params.boolean('isALAAdmin');
 
             boolean destroy = params.destroy == null ? false : params.destroy.toBoolean()
 

--- a/grails-app/controllers/au/org/ala/ecodata/DocumentController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/DocumentController.groovy
@@ -44,7 +44,7 @@ class DocumentController {
             //log.debug list
             asJson([list: list])
         } else {
-            def list = documentService.getAll(params.includeDeleted as boolean, params.view)
+            def list = documentService.getAll(params.boolean('includeDeleted'), params.view)
             list.sort {it.name}
             //log.debug list
             asJson([list: list])


### PR DESCRIPTION
Use 'params.boolean' and 'toBoolean()' instead of 'as Boolean'.

This is necessary to ensure that only "true" / "y" / "1" become true.
Refs: [toBoolean](https://docs.groovy-lang.org/docs/groovy-2.4.10/html/api/org/codehaus/groovy/runtime/StringGroovyMethods.html#toBoolean-java.lang.String-) and [Goovy Truth](https://docs.groovy-lang.org/latest/html/documentation/core-semantics.html#Groovy-Truth).