### PR TITLE
Feature/swedish

### DIFF
--- a/grails-app/conf/data/alaHub.json
+++ b/grails-app/conf/data/alaHub.json
@@ -101,6 +101,17 @@
           "interval": 10,
           "state": "Expanded",
           "title": "Year"
+        },
+        {
+          "isNotHistogram": true,
+          "helpText": "Verification status",
+          "adminOnly": true,
+          "facetTermType": "Default",
+          "formattedName": "Verification status (verificationStatusFacet)",
+          "name": "verificationStatusFacet",
+          "interval": 10,
+          "state": "Expanded",
+          "title": "Verification status"
         }
       ]
     },

--- a/grails-app/conf/data/mapping.json
+++ b/grails-app/conf/data/mapping.json
@@ -490,6 +490,12 @@
           "fields": {
             "surveyYearFacet":{"type":"string", "index":"not_analyzed"}
           }
+        },
+        "verificationStatus": {
+          "type":"string",
+          "fields": {
+            "verificationStatusFacet":{"type":"string", "index":"not_analyzed"}
+          }
         }
       },
       "dynamic_templates": [

--- a/grails-app/services/au/org/ala/ecodata/ElasticSearchService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ElasticSearchService.groovy
@@ -1218,19 +1218,20 @@ class ElasticSearchService {
                     if (userId && (permissionService.isUserAlaAdmin(userId) || permissionService.isUserAdminForProject(userId, projectId) || permissionService.isUserEditorForProject(userId, projectId))) {
                         forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ')'
                     } else if (userId) {
-                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND (projectActivity.embargoed:false OR userId:' + userId + '))'
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND (projectActivity.embargoed:false OR userId:' + userId + ' AND (verificationStatus:3 OR verificationStatus:0)))'
                     } else if (!userId) {
-                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false)'
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
                     }
                 }
                 break
 
             case 'allrecords':
                 if (!projectId) {
+                    // should also check for FC_ADMIN role?
                     if (userId && permissionService.isUserAlaAdmin(userId)) {
                         forcedQuery = '(docType:activity)'
                     } else if (userId) {
-                        forcedQuery = '((docType:activity)'
+                        forcedQuery = '((docType:activity AND (verificationStatus:3 OR verificationStatus:0))'
                         List<String> projectsTheUserIsAMemberOf = permissionService.getProjectsForUser(userId, AccessLevel.admin, AccessLevel.editor)
 
                         projectsTheUserIsAMemberOf?.eachWithIndex { item, index ->
@@ -1248,7 +1249,7 @@ class ElasticSearchService {
                             forcedQuery = forcedQuery + ' AND (projectActivity.embargoed:false OR userId:' + userId + '))'
                         }
                     } else if (!userId) {
-                        forcedQuery = '(docType:activity AND projectActivity.embargoed:false)'
+                        forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
                     }
                 }
                 break
@@ -1258,7 +1259,7 @@ class ElasticSearchService {
                     if (userId && (permissionService.isUserAlaAdmin(userId) || permissionService.isUserAdminForProject(userId, projectId) || permissionService.isUserEditorForProject(userId, projectId))) {
                         forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ')'
                     } else {
-                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false)'
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
                     }
                 }
                 break
@@ -1279,7 +1280,7 @@ class ElasticSearchService {
                 break
 
             default:
-                forcedQuery = '(docType:activity AND projectActivity.embargoed:false)'
+                forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
                 break
         }
 

--- a/grails-app/services/au/org/ala/ecodata/ElasticSearchService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ElasticSearchService.groovy
@@ -1215,12 +1215,14 @@ class ElasticSearchService {
 
             case 'project':
                 if (projectId) {
-                    if (userId && (permissionService.isUserAlaAdmin(userId) || permissionService.isUserAdminForProject(userId, projectId) || permissionService.isUserEditorForProject(userId, projectId))) {
+                    if (userId && (permissionService.isUserAlaAdmin(userId) || permissionService.isUserAdminForProject(userId, projectId))) {
                         forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ')'
+                    } else if (userId && permissionService.isUserEditorForProject(userId, projectId)){
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND ((verificationStatus:approved OR verificationStatus:\"not applicable\") OR userId:' + userId + '))'
                     } else if (userId) {
-                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND (projectActivity.embargoed:false OR userId:' + userId + ' AND (verificationStatus:3 OR verificationStatus:0)))'
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND ((projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\")) OR userId:' + userId + '))'
                     } else if (!userId) {
-                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
                     }
                 }
                 break
@@ -1231,7 +1233,7 @@ class ElasticSearchService {
                     if (userId && permissionService.isUserAlaAdmin(userId)) {
                         forcedQuery = '(docType:activity)'
                     } else if (userId) {
-                        forcedQuery = '((docType:activity AND (verificationStatus:3 OR verificationStatus:0))'
+                        forcedQuery = '((docType:activity)'
                         List<String> projectsTheUserIsAMemberOf = permissionService.getProjectsForUser(userId, AccessLevel.admin, AccessLevel.editor)
 
                         projectsTheUserIsAMemberOf?.eachWithIndex { item, index ->
@@ -1244,12 +1246,12 @@ class ElasticSearchService {
                             forcedQuery = forcedQuery + 'projectActivity.projectId:' + item
                         }
                         if (projectsTheUserIsAMemberOf) {
-                            forcedQuery = forcedQuery + ') OR (projectActivity.embargoed:false OR userId:' + userId + ')))'
+                            forcedQuery = forcedQuery + ') OR ((projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\")) OR userId:' + userId + ')))'
                         } else {
-                            forcedQuery = forcedQuery + ' AND (projectActivity.embargoed:false OR userId:' + userId + '))'
+                            forcedQuery = forcedQuery + ' AND ((projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\")) OR userId:' + userId + '))'
                         }
                     } else if (!userId) {
-                        forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
+                        forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
                     }
                 }
                 break
@@ -1259,7 +1261,7 @@ class ElasticSearchService {
                     if (userId && (permissionService.isUserAlaAdmin(userId) || permissionService.isUserAdminForProject(userId, projectId) || permissionService.isUserEditorForProject(userId, projectId))) {
                         forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ')'
                     } else {
-                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
+                        forcedQuery = '(docType:activity AND projectActivity.projectId:' + projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
                     }
                 }
                 break
@@ -1280,12 +1282,12 @@ class ElasticSearchService {
                 break
 
             default:
-                forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:3 OR verificationStatus:0))'
+                forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
                 break
         }
 
         if (!forcedQuery) {
-            forcedQuery = '(docType:activity AND projectActivity.embargoed:false)'
+            forcedQuery = '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
         }
 
         params.query = query ? query + ' AND ' + forcedQuery : forcedQuery

--- a/test/unit/au/org/ala/ecodata/ElasticSearchServiceSpec.groovy
+++ b/test/unit/au/org/ala/ecodata/ElasticSearchServiceSpec.groovy
@@ -41,7 +41,7 @@ class ElasticSearchServiceSpec extends Specification {
     def cleanup() {
     }
 
-    void "View type : Invalid - Build a query that returns only non-embargoed records"() {
+    void "View type : Invalid - Build a query that returns only non-embargoed records that don't have to be verified or have been approved"() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -53,10 +53,10 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '(docType:activity AND projectActivity.embargoed:false)'
+        map.query == '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
     }
 
-    void "View type: 'myrecords' and empty userId - Build a query that should return only non-embargoed records"() {
+    void "View type: 'myrecords' and empty userId - Build a query that should return only non-embargoed records that don't have to be verified or have been approved"() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -68,7 +68,7 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '(docType:activity AND projectActivity.embargoed:false)'
+        map.query == '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
     }
 
     void "View type: 'myrecords' and valid userId - Build a query that returns all records associated to the user."() {
@@ -101,6 +101,22 @@ class ElasticSearchServiceSpec extends Specification {
         map.query == '(docType:activity AND projectActivity.projectId:' + map.projectId + ')'
     }
 
+        // Admin should see all verificationStatus but editor only their own records...so the below is irrelevant  
+    void "View type: 'project' - if project editor >> show records associated to the project that don't have to be verified or have been approved"() {
+        when:
+        permissionService.isUserAlaAdmin(_) >> false
+        permissionService.isUserAdminForProject(_, _) >> false
+        permissionService.isUserEditorForProject(_, _) >> true
+
+        GrailsParameterMap map = new GrailsParameterMap([getParameterMap: { ->
+            ['userId': "8997", 'projectId': "abc", 'view': "project", 'query': ""]
+        }] as HttpServletRequest)
+        service.buildProjectActivityQuery(map)
+
+        then:
+        map.query == '(docType:activity AND projectActivity.projectId:' + map.projectId + ' AND ((verificationStatus:approved OR verificationStatus:\"not applicable\") OR userId:' + map.userId + '))'
+    }
+
     void "View type: 'project'- if logged in user >> show non embargoed records + records created by user"() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
@@ -113,11 +129,11 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '(docType:activity AND projectActivity.projectId:' + map.projectId + ' AND (projectActivity.embargoed:false OR userId:' + map.userId + '))'
+        map.query == '(docType:activity AND projectActivity.projectId:' + map.projectId + ' AND ((projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\")) OR userId:' + map.userId + '))'
     }
 
 
-    void "View type: 'project'- if unauthenticated user and valid project >> show non embargoed records."() {
+    void "View type: 'project'- if unauthenticated user and valid project >> show non embargoed records that don't have to be verified or have been approved."() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -129,10 +145,10 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '(docType:activity AND projectActivity.projectId:' + map.projectId + ' AND projectActivity.embargoed:false)'
+        map.query == '(docType:activity AND projectActivity.projectId:' + map.projectId + ' AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
     }
 
-    void "View type: 'allrecords' - logged in users and ala admin >> show all records across the projects"() {
+    void "View type: 'allrecords' - logged in users with ala admin role >> show all records across the projects"() {
         when:
         permissionService.isUserAlaAdmin(_) >> true
         permissionService.isUserAdminForProject(_, _) >> false
@@ -147,7 +163,7 @@ class ElasticSearchServiceSpec extends Specification {
         map.query == '(docType:activity)'
     }
 
-    void "View type: 'allrecords' - logged in users and not ala admin >> show embargoed records that user own or been a member of the projects"() {
+    void "View type: 'allrecords' - logged in users and not ala admin >> show embargoed records that user owns or been a member of the projects"() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -160,10 +176,10 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '((docType:activity) AND ((projectActivity.projectId:abc OR projectActivity.projectId:cde) OR (projectActivity.embargoed:false OR userId:' + map.userId + ')))'
+        map.query == '((docType:activity) AND ((projectActivity.projectId:abc OR projectActivity.projectId:cde) OR ((projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\")) OR userId:' + map.userId + ')))'
     }
 
-    void "View type: 'allrecords', logged in users and not ala admin >> show embargoed records that user own "() {
+    void "View type: 'allrecords', logged in users and not ala admin >> show embargoed records that user owns "() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -176,10 +192,10 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '((docType:activity) AND (projectActivity.embargoed:false OR userId:' + map.userId + '))'
+        map.query == '((docType:activity) AND ((projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\")) OR userId:' + map.userId + '))'
     }
 
-    void "View type: 'allrecords' - unauthenticated user >> show only embargoed records across the projects."() {
+    void "View type: 'allrecords' - unauthenticated user >> show only embargoed records that don't have to be verified or have been approved across the projects."() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -192,10 +208,10 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == '(docType:activity AND projectActivity.embargoed:false)'
+        map.query == '(docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
     }
 
-    void "View type: 'allrecords' - unauthenticated user >> show only embargoed records across the projects and attach the searchTerm"() {
+    void "View type: 'allrecords' - unauthenticated user >> show only embargoed records  that don't have to be verified or have been approved across the projects and attach the searchTerm"() {
         when:
         permissionService.isUserAlaAdmin(_) >> false
         permissionService.isUserAdminForProject(_, _) >> false
@@ -208,7 +224,7 @@ class ElasticSearchServiceSpec extends Specification {
         service.buildProjectActivityQuery(map)
 
         then:
-        map.query == 'Test AND (docType:activity AND projectActivity.embargoed:false)'
+        map.query == 'Test AND (docType:activity AND projectActivity.embargoed:false AND (verificationStatus:approved OR verificationStatus:\"not applicable\"))'
     }
 
 


### PR DESCRIPTION
Needed to make the verification feature on BioCollect work: https://github.com/AtlasOfLivingAustralia/biocollect/pull/1330
The changes are mostly to do with ElasticSearch Activity query. The queries need to include verificationStatus of activity.
Activities have the field verificationStatus with possible values: 
  * not applicable (if projectActivity.adminVerification == false) 
  * not approved 
  * not verified 
  * under review 
  * approved
Only admins should see all activities, other permissions should allow displaying only activities with verificationStatus "approved" or "not applicable". Users who added (authored) an activity should be able to see the activity no matter what status it has. 