### PR TITLE
Update elasticsearch minor version #717

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ gormVersion=7.3.2
 gormMongoVersion=7.3.0
 grailsViewsVersion=2.3.2
 assetPipelineVersion=3.3.4
-elasticsearchVersion=7.15.2
+elasticsearchVersion=7.17.9
 mongoDBVersion=7.3.2
 #22.x+ causes issues with mongo / GORM javax.validation.spi, might need grails 5
 geoToolsVersion=21.5

--- a/grails-app/services/au/org/ala/ecodata/SiteService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/SiteService.groovy
@@ -1,15 +1,11 @@
 package au.org.ala.ecodata
 
-
 import com.mongodb.BasicDBObject
 import com.mongodb.DBObject
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoCursor
 import com.mongodb.client.model.Filters
 import grails.converters.JSON
-import org.elasticsearch.common.geo.builders.ShapeBuilder
-import org.elasticsearch.common.xcontent.XContentParser
-import org.elasticsearch.common.xcontent.json.JsonXContent
 import org.geotools.geojson.geom.GeometryJSON
 import org.grails.datastore.mapping.core.Session
 import org.grails.datastore.mapping.engine.event.EventType
@@ -17,7 +13,6 @@ import org.grails.datastore.mapping.query.api.BuildableCriteria
 import org.grails.web.json.JSONObject
 import org.locationtech.jts.geom.Geometry
 
-import static au.org.ala.ecodata.ElasticIndex.HOMEPAGE_INDEX
 import static au.org.ala.ecodata.Status.DELETED
 import static grails.async.Promises.task
 
@@ -828,9 +823,7 @@ class SiteService {
      */
     Boolean isGeoJsonValid(String geoJson){
         try {
-            XContentParser parser = JsonXContent.jsonXContent.createParser(geoJson);
-            parser.nextToken();
-            ShapeBuilder.parse(parser).build();
+            new GeometryJSON().read(geoJson)
         } catch (Exception e){
             log.error('Invalid GeoJson. ' + e.message)
             return false

--- a/src/test/groovy/au/org/ala/ecodata/AuditControllerSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/AuditControllerSpec.groovy
@@ -4,7 +4,6 @@ import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import org.apache.http.HttpStatus
 import org.bson.types.ObjectId
-import org.hsqldb.rights.User
 import spock.lang.Specification
 
 class AuditControllerSpec extends Specification implements ControllerUnitTest<AuditController>, DataTest {

--- a/src/test/groovy/au/org/ala/ecodata/ElasticSearchIndexServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/ElasticSearchIndexServiceSpec.groovy
@@ -263,6 +263,21 @@ class ElasticSearchIndexServiceSpec extends MongoSpec implements ServiceUnitTest
 
     }
 
+    def "Searches can include a shape component"() {
+        setup:
+        String queryString = "name:test"
+        Map params = new GrailsParameterMap([:], null)
+        String index = ElasticIndex.HOMEPAGE_INDEX
+        Map geoSearchCritera = [type:'Polygon', coordinates:[[[1,0], [1, 1], [0, 1], [0, 0], [1, 0]]]]
+
+        when:
+        service.buildSearchRequest(queryString, params, index, geoSearchCritera)
+
+        then:
+        noExceptionThrown()
+
+    }
+
     def  "the aggs parameters is optional"() {
         setup:
         String queryString = ""

--- a/src/test/groovy/au/org/ala/ecodata/SiteServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/SiteServiceSpec.groovy
@@ -57,6 +57,9 @@ class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> 
         geojson.type == 'Polygon'
         geojson.coordinates == [coordinates]
 
+        and: "It can be validated"
+        service.isGeoJsonValid((geojson as JSON).toString())
+
         when: "The site is a drawn circle"
         extent = [source:'drawn', geometry: [type:'Circle', centre: [134.82421875, -33.41310193384], coordinates: [134.82421875, -33.41310193384], radius:12700, pid:'1234']]
         geojson = service.geometryAsGeoJson([extent:extent])
@@ -64,6 +67,7 @@ class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> 
         then: "Circles aren't valid geojson so we need to convert them to a polygon"
         geojson.type == 'Polygon'
         geojson.coordinates[0].size() == 101
+        service.isGeoJsonValid((geojson as JSON).toString())
 
         when: "The site is a line"
         coordinates = [[145.42448043823242,-37.72728027686003],[148.00626754760742,-37.16031654673676],[148.36881637573242,-37.77071473849609],[147.09440231323242,-38.59111377614743]]
@@ -73,6 +77,7 @@ class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> 
         then: "Is site a valid GeoJSON"
         geojson.type == 'LineString'
         geojson.coordinates == coordinates
+        service.isGeoJsonValid((geojson as JSON).toString())
     }
 
     def "Duplicate coordinates must be removed"() {


### PR DESCRIPTION
The changes for this update appear to be because the elastic core library changed some of the GIS related libraries.
This is needed anyway as the High Level Rest Client has been deprecated in favour of the Java Client so we need to remove all of the dependencies on the main ES libraries anyway.

The two changes I've made are only used by BioCollect.
The first validates geojson during the scistarter import.  
The second is to do area based searches for BioCollect.