### PR TITLE
Fixes for BioCollect 6.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'jacoco'
 }
 
-version "4.1-SNAPSHOT"
+version "4.1-biocollect-6.5-SNAPSHOT"
 group "au.org.ala"
 description "Ecodata"
 

--- a/grails-app/controllers/au/org/ala/ecodata/SearchController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/SearchController.groovy
@@ -79,7 +79,7 @@ class SearchController {
             render res
         } else {
             elasticSearchService.buildProjectActivityQuery(params)
-            res = elasticSearchService.search(params.query, params, PROJECT_ACTIVITY_INDEX, [:], true)
+            res = elasticSearchService.search(params.query, params, PROJECT_ACTIVITY_INDEX)
             respond searchResponse:res
         }
 

--- a/grails-app/controllers/au/org/ala/ecodata/SearchController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/SearchController.groovy
@@ -453,6 +453,7 @@ class SearchController {
         if (params.containsKey("isMerit") && !params.isMerit.toBoolean()) {
             params.max = 10000
             params.offset = 0
+            params.userId = params.userId ?: userService.getCurrentUserDetails()?.userId
 
             if (params.async?.toBoolean()) {
                 if (!params.email) {

--- a/grails-app/controllers/au/org/ala/ecodata/SearchController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/SearchController.groovy
@@ -79,7 +79,7 @@ class SearchController {
             render res
         } else {
             elasticSearchService.buildProjectActivityQuery(params)
-            res = elasticSearchService.search(params.query, params, PROJECT_ACTIVITY_INDEX)
+            res = elasticSearchService.search(params.query, params, PROJECT_ACTIVITY_INDEX, [:], true)
             respond searchResponse:res
         }
 

--- a/grails-app/domain/au/org/ala/ecodata/Document.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/Document.groovy
@@ -2,8 +2,6 @@ package au.org.ala.ecodata
 
 import grails.util.Holders
 import org.bson.types.ObjectId
-import org.grails.web.servlet.mvc.GrailsWebRequest
-import org.springframework.web.context.request.RequestAttributes
 
 import static au.org.ala.ecodata.Status.ACTIVE
 /**
@@ -101,7 +99,7 @@ class Document {
         return urlFor(filepath, filename)
     }
 
-    def getThumbnailUrl() {
+    def getThumbnailUrl(boolean skipExistCheck = false) {
         if (isImage()) {
 
             if(isImageHostedOnPublicServer()) {
@@ -109,7 +107,7 @@ class Document {
             }
 
             File thumbFile = new File(filePath(THUMBNAIL_PREFIX+filename))
-            if (thumbFile.exists()) {
+            if (skipExistCheck || thumbFile.exists()) {
                 return urlFor(filepath, THUMBNAIL_PREFIX + filename)
             }
             else {

--- a/grails-app/services/au/org/ala/ecodata/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/DownloadService.groovy
@@ -322,7 +322,7 @@ class DownloadService {
                 documentList.each { doc ->
                     if (doc.type == Document.DOCUMENT_TYPE_IMAGE) {
                        // if (!documentMap.containsKey(doc.documentId)) {
-                            addFileToZip(zip, recordIdPath, doc, documentMap, paths)
+                            addFileToZip(zip, recordIdPath, doc, documentMap, paths, true)
                        // }
                         recordMap[recordId] << doc
                     }

--- a/grails-app/services/au/org/ala/ecodata/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/DownloadService.groovy
@@ -381,15 +381,15 @@ class DownloadService {
         if (thumbnail) {
             file = documentService.makeThumbnail(doc.filepath, doc.filename, false)
         }
+        String thumbnailURL = doc.getThumbnailUrl(true)
         if (file != null && file.exists()) {
             zip.putNextEntry(new ZipEntry(zipName))
             file.withInputStream { i -> zip << i }
         }
-        else if (doc.getUrl()) {
+        else if (thumbnailURL) {
             // reporting server does not hold images.
             // download it by requesting image from BioCollect/MERIT
-            url = doc.getUrl()
-            def stream = webService.getStream(url, true)
+            def stream = webService.getStream(thumbnailURL, true)
             if (!(stream instanceof Map)) {
                 zip.putNextEntry(new ZipEntry(zipName))
                 zip << stream

--- a/grails-app/services/au/org/ala/ecodata/ElasticSearchService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ElasticSearchService.groovy
@@ -106,7 +106,7 @@ class ElasticSearchService {
     RestHighLevelClient client
     ElasticSearchIndexManager indexManager
     def indexingTempInactive = false // can be set to true for loading of dump files, etc
-    def ALLOWED_DOC_TYPES = [Project.class.name, Site.class.name, Document.class.name, Activity.class.name, Record.class.name, Organisation.class.name, UserPermission.class.name, Program.class.name]
+    def ALLOWED_DOC_TYPES = [Project.class.name, Site.class.name, Document.class.name, Activity.class.name, Record.class.name, Organisation.class.name, UserPermission.class.name, Program.class.name, Output.class.name]
     def DEFAULT_FACETS = 10
     private static Queue<IndexDocMsg> _messageQueue = new ConcurrentLinkedQueue<IndexDocMsg>()
 
@@ -589,6 +589,12 @@ class ElasticSearchService {
                 }
                 break
 
+            case Output.class.name:
+                Output output = Output.findByOutputId(docId)
+                if (output) {
+                    indexDocType(output.activityId, Activity.class.name)
+                }
+                break
             case Activity.class.name:
                 Activity activity = Activity.findByActivityId(docId)
                 def doc = activityService.toMap(activity, ActivityService.FLAT)

--- a/grails-app/services/au/org/ala/ecodata/ProjectActivityService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ProjectActivityService.groovy
@@ -135,7 +135,7 @@ class ProjectActivityService {
     private static updateEmbargoDetails(ProjectActivity projectActivity, Map incomingProperties) {
         if(incomingProperties.visibility) {
             EmbargoOption option = incomingProperties.visibility?.embargoOption as EmbargoOption
-            VisibilityConstraint visibility = new VisibilityConstraint()
+            VisibilityConstraint visibility = projectActivity.visibility ?: new VisibilityConstraint()
 
             // Project admin and Moderator defined embargo settings.
             switch (option) {
@@ -159,7 +159,7 @@ class ProjectActivityService {
             // ALA admin - Defined embargo settings.
             visibility.alaAdminEnforcedEmbargo = incomingProperties.visibility?.alaAdminEnforcedEmbargo
             incomingProperties.remove("visibility")
-            projectActivity.visibility = visibility
+            projectActivity.markDirty('visibility')
         }
     }
 
@@ -388,7 +388,7 @@ class ProjectActivityService {
     def notifiableProperties (Map body, Map old) {
         List notify = []
         SUBSCRIBED_PROPERTIES.each {
-            if (old[it] != body[it]) {
+            if (old.hasProperty(it) && (old[it] != body[it])) {
                 notify.add(it)
             }
         }

--- a/grails-app/services/au/org/ala/ecodata/ProjectActivityService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ProjectActivityService.groovy
@@ -388,7 +388,7 @@ class ProjectActivityService {
     def notifiableProperties (Map body, Map old) {
         List notify = []
         SUBSCRIBED_PROPERTIES.each {
-            if (old.hasProperty(it) && (old[it] != body[it])) {
+            if (body.containsKey(it) && (old[it] != body[it])) {
                 notify.add(it)
             }
         }

--- a/src/test/groovy/au/org/ala/ecodata/ProjectActivityServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/ProjectActivityServiceSpec.groovy
@@ -49,4 +49,40 @@ class ProjectActivityServiceSpec extends MongoSpec implements ServiceUnitTest<Pr
         result == true
     }
 
+    def "should return an notifiable property when creating project activity"() {
+        given:
+        def body = [foo: 1, methodName: 2]
+        def old = [:]
+
+        expect:
+        service.notifiableProperties(body, old) == ['methodName']
+    }
+
+    def "should return an empty list when there are no changes to subscribed properties"() {
+        given:
+        def body = [foo: 1, methodName: 2]
+        def old = [foo: 1, methodName: 2]
+
+        expect:
+        service.notifiableProperties(body, old) == []
+    }
+
+    def "should return a list of changed subscribed properties"() {
+        given:
+        def body = [foo: 1, methodName: 2]
+        def old = [foo: 1, methodName: 3]
+
+        expect:
+        service.notifiableProperties(body, old) == ['methodName']
+    }
+
+    def "should not return properties that are not subscribed"() {
+        given:
+        def body = [foo: 1, methodName: 3]
+        def old = [foo: 2, methodName: 3]
+
+        expect:
+        service.notifiableProperties(body, old) == []
+    }
+
 }


### PR DESCRIPTION
AtlasOfLivingAustralia/biocollect#1465
- fixes issue with going to last page of activity list

AtlasOfLivingAustralia/biocollect#1499
- another fix for download includes only thumbnails images

AtlasOfLivingAustralia/biocollect#1507
- updating output of an activity should trigger reindex of activity

AtlasOfLivingAustralia/biocollect#1407
- fixed embargo settings not clearing invalid settings (days and date)

AtlasOfLivingAustralia/biocollect#1285
- fixed project activity sending unnecessary notification emails

