### PR TITLE
devt.ala.org.au->localhost, delete unused role migration code #850

### DIFF
--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -576,8 +576,7 @@ grails.cache.config = {
 security {
     cas {
         enabled = false
-        appServerName = 'http://devt.ala.org.au:8080' // or similar, up to the request path part
-        // service = 'http://devt.ala.org.au:8080' // optional, if set it will always be used as the return path from CAS
+        appServerName = 'http://localhost:8080' // or similar, up to the request path part
         casServerUrlPrefix = 'https://auth-test.ala.org.au/cas'
         loginUrl = 'https://auth-test.ala.org.au/cas/login'
         logoutUrl = 'https://auth-test.ala.org.au/cas/logout'
@@ -605,6 +604,10 @@ security {
         readTimeoutMs = 20000
     }
 }
+webservice.jwt = true
+webservice['jwt-scopes'] = "ala/internal users/read ala/attrs users/read"
+webservice['client-id']='changeMe'
+webservice['client-secret'] = 'changeMe'
 
 grails.gorm.graphql.browser = true
 
@@ -613,10 +616,10 @@ environments {
         grails.logging.jul.usebridge = true
         ecodata.use.uuids = false
         app.external.model.dir = "/data/ecodata/models/" //"./models/"
-        grails.hostname = "devt.ala.org.au"
+        grails.hostname = "localhost"
         app.elasticsearch.indexAllOnStartup = false
         app.elasticsearch.indexOnGormEvents = true
-        grails.serverURL = "http://devt.ala.org.au:8080"
+        grails.serverURL = "http://${grails.hostname}:8080"
         app.uploads.url = "/document/download/"
         grails.mail.host="localhost"
         grails.mail.port=1025
@@ -632,7 +635,7 @@ environments {
         grails.logging.jul.usebridge = true
         ecodata.use.uuids = false
         app.external.model.dir = "./models/"
-        grails.hostname = "devt.ala.org.au"
+        grails.hostname = "localhost"
         // Only for travis CI, they must be overriden by ecodata-config.properties
         serverName = "http://${grails.hostname}:8080"
         grails.app.context = "ecodata"
@@ -651,7 +654,7 @@ environments {
 
         wiremock.port = 8018
         security.cas.bypass = true
-        security.cas.casServerUrlPrefix="http://devt.ala.org.au:${wiremock.port}/cas"
+        security.cas.casServerUrlPrefix="http://localhost:${wiremock.port}/cas"
         security.cas.loginUrl="${security.cas.casServerUrlPrefix}/login"
     }
     meritfunctionaltest {
@@ -664,7 +667,7 @@ environments {
         grails.logging.jul.usebridge = true
         ecodata.use.uuids = false
         app.external.model.dir = "./models/"
-        grails.serverURL = "http://devt.ala.org.au:8080"
+        grails.serverURL = "http://localshot:8080"
         app.uploads.url = "${grails.serverURL}/document/download?filename="
 
         app.elasticsearch.indexOnGormEvents = true
@@ -675,7 +678,7 @@ environments {
         wiremock.port = 8018
         security.oidc.discoveryUri = "http://localhost:${wiremock.port}/cas/oidc/.well-known"
         security.oidc.allowUnsignedIdTokens = true
-        def casBaseUrl = "http://devt.ala.org.au:${wiremock.port}"
+        def casBaseUrl = "http://localhost:${wiremock.port}"
         security.cas.casServerName="${casBaseUrl}"
         security.cas.contextPath=""
         security.cas.casServerUrlPrefix="${casBaseUrl}/cas"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -257,7 +257,7 @@ graphiql:
 
 
 casUrl: https://auth-test.ala.org.au/cas/logout
-appUrl: http://devt.ala.org.au:8080/admin
+appUrl: http://localhost:8080/admin
 
 
 openapi:

--- a/grails-app/services/au/org/ala/ecodata/PermissionService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/PermissionService.groovy
@@ -644,53 +644,6 @@ class PermissionService {
     }
 
     /**
-     * This code snippet is based on ReportService.userSummary
-     * Produces a list of users containing roles below:
-     * (ROLE_FC_READ_ONLY,ROLE_FC_OFFICER,ROLE_FC_ADMIN)
-     */
-    private def extractUserDetails() {
-        List roles = ['ROLE_FC_READ_ONLY', 'ROLE_FC_OFFICER', 'ROLE_FC_ADMIN']
-        def userDetailsSummary = [:]
-
-        int batchSize = 500
-
-        String url = grailsApplication.config.getProperty('userDetails.admin.url')
-        url += "/userRole/list?format=json&max=${batchSize}&role="
-        roles.each { role ->
-            int offset = 0
-            Map result = webService.getJson(url+role+'&offset='+offset)
-
-            while (offset < result?.count && !result?.error) {
-
-                List usersForRole = result?.users ?: []
-                usersForRole.each { user ->
-                    if (userDetailsSummary[user.userId]) {
-                        userDetailsSummary[user.userId].role = role
-                    }
-                    else {
-                        user.projects = []
-                        user.name = (user.firstName ?: "" + " " +user.lastName ?: "").trim()
-                        user.role = role
-                        userDetailsSummary[user.userId] = user
-                    }
-
-
-                }
-
-                offset += batchSize
-                result = webService.getJson(url+role+'&offset='+offset)
-            }
-
-            if (!result || result.error) {
-                log.error("Error getting user details for role: "+role)
-                return
-            }
-        }
-
-        userDetailsSummary
-    }
-
-    /**
      * This method finds the hubId of the entity specified in the supplied UserPermission.
      * Currently only Project, Organisation, ManagementUnit, Program are supported.
      */
@@ -707,34 +660,6 @@ class PermissionService {
             }
         }
         hubId
-    }
-
-    def saveUserDetails() {
-        def map = [ROLE_FC_ADMIN: "admin", ROLE_FC_OFFICER: "caseManager", ROLE_FC_READ_ONLY: "readOnly"]
-        String urlPath = "merit"
-        String hubId = hubService.findByUrlPath(urlPath)?.hubId
-
-        //extracts from UserDetails
-        def userDetailsSummary = extractUserDetails()
-
-        //save to userPermission
-        userDetailsSummary.each { key, value ->
-            value.roles.each { role ->
-                if (map[role]) {
-                    UserPermission userP = UserPermission.findByUserIdAndEntityIdAndEntityType(key, hubId, Hub.name)
-                    try {
-                        if (!userP) {
-                            UserPermission up = new UserPermission(userId: key, entityId: hubId, entityType: Hub.name, accessLevel: AccessLevel.valueOf(map[role]))
-                            up.save(flush: true, failOnError: true)
-                        }
-                    } catch (Exception e) {
-                        def msg = "Failed to save UserPermission: ${e.message}"
-                        return [status: 'error', error: msg]
-                    }
-                }
-
-            }
-        }
     }
 
     private Map saveUserToHubEntity(Map params) {

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -16,7 +16,7 @@
   },
   "servers":[
     {
-      "url":"http://devt.ala.org.au:8080"
+      "url":"http://localhost:8080"
     }
   ],
   "paths":{

--- a/src/test/groovy/au/org/ala/ecodata/SchemaBuilderSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/SchemaBuilderSpec.groovy
@@ -88,7 +88,7 @@ class SchemaBuilderSpec extends Specification implements GrailsUnitTest {
 
         then:
         schema == [
-                id:"http://devt.ala.org.au:8080/ecodata/ws/documentation/draft/output/Test%20Output",
+                id:"http://localhost:8080/ecodata/ws/documentation/draft/output/Test%20Output",
                 $schema:"http://json-schema.org/draft-04/schema#",
                 type:"object",
                 properties:[
@@ -111,7 +111,7 @@ class SchemaBuilderSpec extends Specification implements GrailsUnitTest {
 
         then:
         schema == [
-                id:"http://devt.ala.org.au:8080/ecodata/ws/documentation/draft/output/Test%20Output",
+                id:"http://localhost:8080/ecodata/ws/documentation/draft/output/Test%20Output",
                 $schema:"http://json-schema.org/draft-04/schema#",
                 type:"object",
                 properties:[
@@ -140,7 +140,7 @@ class SchemaBuilderSpec extends Specification implements GrailsUnitTest {
 
         then:
         schema == [
-                id:"http://devt.ala.org.au:8080/ecodata/ws/documentation/draft/output/Test%20Output",
+                id:"http://localhost:8080/ecodata/ws/documentation/draft/output/Test%20Output",
                 $schema:"http://json-schema.org/draft-04/schema#",
                 type:"object",
                 properties:[


### PR DESCRIPTION
@temi I've added you as a reviewer mostly as an FYI, the change here just switches devt.ala.org.au -> localhost to support cognito callback rules and adds a couple of config items for ecodata application auth.