### PR TITLE
fixes two exceptions updating site metadata - AtlasOfLivingAustralia/fieldcapture#3292

### DIFF
--- a/grails-app/services/au/org/ala/ecodata/SpatialService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/SpatialService.groovy
@@ -166,7 +166,7 @@ class SpatialService {
         List checkForBoundaryIntersectionInLayers = metadataService.getGeographicConfig().checkForBoundaryIntersectionInLayers
         if (!mainGeometry.isValid()) {
             log.info("Main geometry invalid. Cannot check intersection is near boundary.")
-            return response
+            return [response, [:]]
         }
         Map filteredResponse = [:]
         Map intersectionAreaByFacets = [:].withDefault { [:] }
@@ -241,11 +241,16 @@ class SpatialService {
         double intersectArea = intersection.getArea()
         double mainGeometryArea = mainGeometry.getArea()
         double proportion = 0.0
+        double area = 0.0d
         if (mainGeometryArea != 0.0d) {
             proportion = intersectArea/mainGeometryArea
         }
 
-        [proportion, GeometryUtils.area(intersection)]
+        if (intersectArea != 0.0d) {
+            area = GeometryUtils.area(intersection)
+        }
+
+        [proportion, area]
     }
 
     /**


### PR DESCRIPTION
java.lang.IllegalStateException: getX called on empty Point
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object