### PR TITLE
Feature/issue2382

### DIFF
--- a/grails-app/controllers/au/org/ala/ecodata/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/AdminController.groovy
@@ -161,6 +161,15 @@ class AdminController {
         flash.message = "Search index re-indexed - ${resp?.size()} docs"
         render "Indexing done"
     }
+
+    @au.ala.org.ws.security.RequireApiKey(scopesFromProperty=["app.writeScope"])
+    def reindexProjects() {
+        Map params = request.JSON
+        int count = elasticSearchService.indexProjectsWithCriteria(params)
+        Map resp = [indexedCount:count]
+        render resp as JSON
+    }
+
     @au.ala.org.ws.security.RequireApiKey(scopesFromProperty=["app.writeScope"])
     def clearMetadataCache() {
         // clear any cached external config

--- a/grails-app/controllers/au/org/ala/ecodata/ManagementUnitController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/ManagementUnitController.groovy
@@ -58,8 +58,14 @@ class ManagementUnitController {
                 respond null
             }
             else {
+                String originalName = mu.name
                 bindData(mu, request.JSON, [include:ManagementUnit.bindingProperties])
-                respond managementUnitService.save(mu)
+                ManagementUnit savedMu = managementUnitService.save(mu)
+                // Update the project search index if the program name has changed.
+                if (originalName != savedMu.name) {
+                    elasticSearchService.reindexProjectsWithCriteriaAsync(managementUnitId:id)
+                }
+                respond savedMu
             }
         }
     }

--- a/src/test/groovy/au/org/ala/ecodata/ProgramServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/ProgramServiceSpec.groovy
@@ -9,11 +9,14 @@ import spock.lang.Specification
 class ProgramServiceSpec extends MongoSpec implements ServiceUnitTest<ProgramService> {
 
     CommonService commonService = new CommonService()
+    ElasticSearchService elasticSearchService = Mock(ElasticSearchService)
 
     def setup() {
         commonService.grailsApplication = grailsApplication
         commonService.messageSource = Mock(MessageSource)
         service.commonService = commonService
+        service.elasticSearchService = elasticSearchService
+
 
         Program.findAll().each { it.delete(flush:true) }
     }
@@ -56,6 +59,7 @@ class ProgramServiceSpec extends MongoSpec implements ServiceUnitTest<ProgramSer
         program.externalIds.size() == 1
         program.externalIds[0].idType == ExternalId.IdType.GRANT_AWARD
         program.externalIds[0].externalId == "e1"
+        1 * elasticSearchService.reindexProjectsWithCriteriaAsync([programId:'1'])
     }
 
     void "update existing Parent with new parent program"(){


### PR DESCRIPTION
The admin controller method to support ad-hoc reindexing and the new program page function in MERIT - main use case there is when programs get hidden/un-hidden we can just re-index that program rather than the whole system