### PR TITLE
fixed an issue with management unit site being skipped AtlasOfLivingAustralia/fieldcapture#3292

### DIFF
--- a/grails-app/controllers/au/org/ala/ecodata/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/AdminController.groovy
@@ -270,7 +270,8 @@ class AdminController {
         def defaultStartDate = "2018-01-01"
         def timeZoneUTC = TimeZone.getTimeZone("UTC")
         dateFormat.setTimeZone(timeZoneUTC)
-        def isMERIT = params.getBoolean('isMERIT', true)
+        Boolean isForceFetch = params.getBoolean('force', true)
+        Boolean isMERIT = params.getBoolean('isMERIT', true)
         Date startDate = params.getDate("startDate", ["yyyy", "yyyy-MM-dd"]) ?: dateFormat.parse(defaultStartDate)
         List siteIds = params.get("siteId")?.split(",") ?: []
         List projectIds = params.get("projectId")?.split(",") ?: []
@@ -332,13 +333,20 @@ class AdminController {
                             log.info("${total+1} or ${(total+1)*100/totalSites} % sites updated in db..")
                         }
 
-                        if (!site.projects || !site.extent) {
-                            log.debug("Ignoring site ${site.siteId} due to no associated projects or no extent")
+                        if (!site.extent) {
+                            log.debug("Ignoring site ${site.siteId} due to no extent")
                             return
                         }
-                        def projectsOfSite = site.projects
-                        List hubIds = projectService.findHubIdOfProjects(projectsOfSite)
+                        // management unit site does not have any projects
+                        def projectsOfSite = site.projects ?: []
+                        List hubIds = projectService.findHubIdFromProjectsOrCurrentHub(projectsOfSite)
                         def fids = hubIds.size() == 1 ? metadataService.getSpatialLayerIdsToIntersect(hubIds[0]) : defaultFids
+
+                        if (!isForceFetch && siteService.areIntersectionCalculatedForAllLayers(site)) {
+                            log.debug("Skipping site ${site.siteId} as all layers are already calculated and force fetch is not enabled - $isForceFetch")
+                            return // Skip if all layers are already calculated
+                        }
+
                         siteService.populateLocationMetadataForSite(site, fids)
                         endInterimTime = System.currentTimeMillis()
                         log.debug("Time taken to update metadata ${site.siteId}: ${endInterimTime - startInterimTime} ms")

--- a/grails-app/services/au/org/ala/ecodata/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/MetadataService.groovy
@@ -490,7 +490,7 @@ class MetadataService {
      * @return
      */
     List<String> getSpatialLayerIdsToIntersectForProjects(List projectIds = []) {
-        List hubIds = projectService.findHubIdOfProjects(projectIds)
+        List hubIds = projectService.findHubIdFromProjectsOrCurrentHub(projectIds)
         hubIds.size() == 1 ? getSpatialLayerIdsToIntersect(hubIds[0]) : getSpatialLayerIdsToIntersect()
     }
 

--- a/grails-app/services/au/org/ala/ecodata/ProjectService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ProjectService.groovy
@@ -51,6 +51,7 @@ class ProjectService {
     ActivityFormService activityFormService
     RecordService recordService
     LockService lockService
+    HubService hubService
 
   /*  def getCommonService() {
         grailsApplication.mainContext.commonService
@@ -1224,6 +1225,21 @@ class ProjectService {
             projections {
                 property('hubId')
             }
+        }
+    }
+
+    /**
+     * Find hubs from project or use hubId query parameter
+     * @param projects
+     * @return
+     */
+    def findHubIdFromProjectsOrCurrentHub (List projects) {
+        if (projects) {
+            return findHubIdOfProjects(projects)
+        }
+        else {
+            def currentHub = hubService.getCurrentHub()
+            return currentHub ? [currentHub.hubId] : []
         }
     }
 

--- a/grails-app/services/au/org/ala/ecodata/SiteService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/SiteService.groovy
@@ -708,7 +708,7 @@ class SiteService {
      */
     def mergeIntersectionsArea(Map site, Map intersectionsAreaByFacets) {
         Map geometry = site.extent.geometry
-        List hubs = projectService.findHubIdOfProjects(site.projects)
+        List hubs = projectService.findHubIdFromProjectsOrCurrentHub(site.projects)
         String hubId = hubs?.size() == 1 ? hubs[0] : null
         Map existingIntersectionsArea = geometry[SpatialService.INTERSECTION_AREA] = geometry[SpatialService.INTERSECTION_AREA] ?: [:]
         intersectionsAreaByFacets?.each { String layer, Map nameAndValue ->
@@ -1061,5 +1061,19 @@ class SiteService {
 
     List filterSitesByPurposeIsPlanning (List<Map> sites) {
         sites?.findAll { getPurpose(it) == Site.PLANNING_SITE_CODE }
+    }
+
+    /**
+     * Check if the intersection area is calculated for all provided layers
+     * @param site
+     * @param fids
+     * @return
+     */
+    Boolean areIntersectionCalculatedForAllLayers(def site){
+        List fids = metadataService.getGeographicConfig().checkForBoundaryIntersectionInLayers
+        fids?.every { fid ->
+            String group = metadataService.getGeographicFacetConfig(fid, null)?.name
+            site.extent?.geometry?[SpatialService.INTERSECTION_AREA]?[group]?[fid] != null
+        }
     }
 }

--- a/src/test/groovy/au/org/ala/ecodata/SiteServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/SiteServiceSpec.groovy
@@ -194,7 +194,7 @@ class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> 
     def "New sites without a centroid should have one assigned"() {
         when:
         def result
-        projectService.findHubIdOfProjects(_) >> []
+        projectService.findHubIdFromProjectsOrCurrentHub(_) >> []
         Site.withSession { session ->
             result = service.create([name: 'Site 1', extent: [source: 'pid', geometry: [type: 'pid', pid: 'cl123']]])
             session.flush()
@@ -310,7 +310,7 @@ class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> 
 
     def "The site area is calculated from the FeatureCollection for a compound site"() {
         setup:
-        projectService.findHubIdOfProjects(_) >> []
+        projectService.findHubIdFromProjectsOrCurrentHub(_) >> []
         def coordinates = [[148.260498046875, -37.26530995561874], [148.260498046875, -37.26531995561874], [148.310693359375, -37.26531995561874], [148.310693359375, -37.26531995561874], [148.260498046875, -37.26530995561874]]
         def extent = buildExtent('drawn', 'Polygon', coordinates)
         Map site = [type: Site.TYPE_COMPOUND, extent: extent, features: [


### PR DESCRIPTION
- added force parameter to skip if calculation already done
- fixed an issue with management unit site being skipped
- get geo config of hub using project or current hub