### PR TITLE
Ingore sites.area when indexing AtlasOfLivingAustralia/fieldcapture#3482

### DIFF
--- a/grails-app/conf/data/mapping.json
+++ b/grails-app/conf/data/mapping.json
@@ -281,6 +281,10 @@
             "notes": {
               "type": "text"
             },
+            "area": {
+              "type": "text",
+              "index": false
+            },
             "features": {
               "type": "object",
               "enabled": false


### PR DESCRIPTION
When testing the organisation indexing fix I found this issue