### PR TITLE
Feature/issue3565

### DIFF
--- a/grails-app/services/au/org/ala/ecodata/SiteService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/SiteService.groovy
@@ -302,12 +302,12 @@ class SiteService {
         }
     }
 
-    def update(Map props, String id, boolean enableCentroidRefresh = true) {
+    def update(Map props, String id, boolean forceRefresh = false) {
         Site site = Site.findBySiteId(id)
 
         if (site) {
             try {
-                updateSite(site, props, enableCentroidRefresh)
+                updateSite(site, props, forceRefresh)
                 return [status:'ok']
             } catch (Exception e) {
                 Site.withSession { session -> session.clear() }
@@ -332,7 +332,7 @@ class SiteService {
 
         assignPOIIds(props)
         // If the site location is being updated, refresh the location metadata.
-        if (forceRefresh || hasGeometryChanged(toMap(site), props)) {
+        if (forceRefresh || hasGeometryChanged(toMap(site, FLAT), props)) {
             if (asyncUpdate){
                 // Sharing props object between thread causes ConcurrentModificationException.
                 // Cloned object is used by spawned thread.
@@ -371,7 +371,8 @@ class SiteService {
 
         return (site.extent?.source != newProps.extent.source) ||
                 (site.extent?.geometry?.coordinates != newProps.extent.geometry.coordinates) ||
-                (site.extent?.geometry?.pid != newProps.extent.geometry.pid)
+                (site.extent?.geometry?.pid != newProps.extent.geometry.pid) ||
+                (site.features != newProps.features)
     }
 
     void delete(String siteId, boolean destroy = false) {

--- a/grails-app/services/au/org/ala/ecodata/SpatialService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/SpatialService.groovy
@@ -111,33 +111,10 @@ class SpatialService {
 
         start = end
 
-        Map geographicFacets
-        Map intersectionAreaForFacets = [:].withDefault{ [:].withDefault{0.0d} }
-        if (geo.geometryType == 'GeometryCollection') {
-            geographicFacets = [:].withDefault{[]}
-            GeometryCollection geometryCollection = (GeometryCollection)geo
-            for (int i=0; i<geometryCollection.numGeometries; i++) {
-                def (filtered, intersectionArea) = filterOutObjectsInBoundary(result, geometryCollection.getGeometryN(i))
-                start = end
-                Map geographicFacetsForGeometry = convertResponsesToGeographicFacets(filtered)
-                geographicFacetsForGeometry.each { k, v ->
-                    geographicFacets[k] += v
-                    geographicFacets[k] = geographicFacets[k].unique()
-                }
-                intersectionArea.each { k, v ->
-                    v.each { fieldName, area ->
-                        intersectionAreaForFacets[k][fieldName] =  intersectionAreaForFacets[k][fieldName] + area
-                    }
-                }
-            }
-            
-            geographicFacets[INTERSECTION_AREA] = intersectionAreaForFacets
-        }
-        else {
-            def (filtered, intersectionArea) = filterOutObjectsInBoundary(result, geo)
-            geographicFacets = convertResponsesToGeographicFacets(filtered)
-            geographicFacets[INTERSECTION_AREA] = intersectionArea
-        }
+        def (filtered, intersectionArea) = filterOutObjectsInBoundary(result, geo)
+        Map geographicFacets = convertResponsesToGeographicFacets(filtered)
+        geographicFacets[INTERSECTION_AREA] = intersectionArea
+
         end = System.currentTimeMillis()
         log.info("Time taken to convert responses to geographic facets: ${end-start}ms")
         geographicFacets

--- a/src/test/groovy/au/org/ala/ecodata/SiteServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/SiteServiceSpec.groovy
@@ -3,6 +3,8 @@ package au.org.ala.ecodata
 import com.mongodb.BasicDBObject
 import grails.converters.JSON
 import grails.test.mongodb.MongoSpec
+import grails.testing.gorm.DataTest
+import grails.testing.gorm.DomainUnitTest
 import grails.testing.services.ServiceUnitTest
 import org.grails.web.converters.marshaller.json.CollectionMarshaller
 
@@ -14,7 +16,7 @@ import org.grails.web.converters.marshaller.json.MapMarshaller
  * Specification / tests for the SiteService
  */
 
-class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> {
+class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService>, DomainUnitTest<Site> {
 
     //def service = new SiteService()
     def webServiceMock = Mock(WebService)
@@ -39,10 +41,12 @@ class SiteServiceSpec extends MongoSpec implements ServiceUnitTest<SiteService> 
         service.projectService = projectService
      //   grailsApplication.mainContext.registerSingleton('commonService', CommonService)
      //   grailsApplication.mainContext.commonService.grailsApplication = grailsApplication
+
+        Site.findAll().each { it.delete(flush:true) }
     }
 
     void cleanup() {
-        Site.collection.remove(new BasicDBObject())
+        Site.findAll().each { it.delete(flush:true) }
     }
 
     // We should be storing the extent geometry as geojson already to enable geographic searching using


### PR DESCRIPTION
Since upgrading geotools/JTS the intersection routine now works with a GeometryCollection which means we can intersect a multi feature site in a single call.
I've tested this on the problematic site from yesterday (that had ~10000 features over a large area (2million Ha and hence a few electorates)) and it reduced the intersection time from 30 mins to about 10 seconds (probably at least in part because it avoids the ehcache issue)