### PR TITLE
Add 'bs5' as valid hub skin option

### DIFF
--- a/grails-app/domain/au/org/ala/ecodata/Hub.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/Hub.groovy
@@ -94,7 +94,7 @@ class Hub implements ProcessEmbedded {
 
     static constraints = {
         urlPath unique: true
-        skin inList: ['ala2', 'nrm','mdba','ala', 'configurableHubTemplate1', 'bs4']
+        skin inList: ['ala2', 'nrm','mdba','ala', 'configurableHubTemplate1', 'bs4', 'bs5']
         title nullable:true
         homePagePath nullable:true
         defaultProgram nullable: true


### PR DESCRIPTION
Currently, hub config changes in BioCollect are failing, as 'bs5' is not considered a valid value for the hub skin.