### PR TITLE
Added hub description & PWA visibility configuration, added ws endpoint for fetching PWA hubs

### DIFF
--- a/grails-app/controllers/au/org/ala/ecodata/HubController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/HubController.groovy
@@ -57,6 +57,11 @@ class HubController  {
         }
     }
 
+    def findPWAHubs() {
+        List hubs = hubService.findHubsToShowInPWA()
+        asJson([list: hubs])
+    }
+
     @au.ala.org.ws.security.RequireApiKey(scopesFromProperty=["app.writeScope"])
     def update(String id) {
         Map props = request.JSON

--- a/grails-app/domain/au/org/ala/ecodata/Hub.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/Hub.groovy
@@ -12,6 +12,8 @@ class Hub implements ProcessEmbedded {
     String hubId
     /** The title for the hub - used in the banner in the nrm hub */
     String title
+    /** A brief description of the hub - used in the PWA */
+    String description
     /** The path used to access this hub (must appear as the first path after the context path) */
     String urlPath
     /** One of ala2 or nrm - defines the look of pages accessed via this hub */
@@ -20,6 +22,8 @@ class Hub implements ProcessEmbedded {
     List supportedPrograms
     /** New projects created from this hub will inherit the default program, if specified */
     String defaultProgram
+    /** Defines whether the hub should be visible in the PWA */
+    Boolean showInPWA
     /** Defines the full set of facets available for use on search pages for this hub */
     List availableFacets
     /** Defines the subset of availableFacets that should only be visible to FC_ADMINS */
@@ -96,8 +100,10 @@ class Hub implements ProcessEmbedded {
         urlPath unique: true
         skin inList: ['ala2', 'nrm','mdba','ala', 'configurableHubTemplate1', 'bs4', 'bs5']
         title nullable:true
+        description nullable:true
         homePagePath nullable:true
         defaultProgram nullable: true
+        showInPWA nullable: true
         templateConfiguration nullable: true
         content nullable: true
         customBreadCrumbs nullable: true

--- a/grails-app/services/au/org/ala/ecodata/HubService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/HubService.groovy
@@ -138,4 +138,9 @@ class HubService implements DataBinder {
         }
     }
 
+    /** Returns a list of hubs that are configured for PWA visibility */
+    List<Hub> findHubsToShowInPWA() {
+        Hub.where { showInPWA == true }.list()
+    }
+
 }

--- a/src/test/groovy/au/org/ala/ecodata/HubServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/HubServiceSpec.groovy
@@ -70,4 +70,12 @@ class HubServiceSpec extends MongoSpec implements ServiceUnitTest<HubService>, D
         result.hubId == 'id'
         result.urlPath == 'test'
     }
+
+    void "hubs configured to be visible in PWA are returned"() {
+        setup:
+        new Hub(urlPath:"test1", hubId:"hub1", showInPWA:true, accessManagementOptions: [expireUsersAfterDurationInactive:"P24M", warnUsersAfterDurationInactive:"P23M"]).save(flush:true, deleteOnerror:true)
+
+        expect:
+        service.findHubsToShowInPWA().size() == 1
+    }
 }


### PR DESCRIPTION
This pull request introduces enhancements to support Progressive Web App (PWA) visibility for hubs, including new fields in the `Hub` domain and supporting API/service methods. The key changes are grouped below:

**PWA Visibility Feature:**

* Added a new `showInPWA` Boolean field to the `Hub` domain to indicate whether a hub should be visible in the PWA, including nullable constraints.
* Added a new `description` field to the `Hub` domain for use in the PWA, with nullable constraints.

**API and Service Support:**

* Implemented the `findHubsToShowInPWA` method in `HubService` to return hubs configured for PWA visibility.
* Added the `findPWAHubs` controller action in `HubController` to expose the list of PWA-visible hubs via API.