### PR TITLE
Treat null data the same as error due to difference between s3 & file…

### DIFF
--- a/grails-app/services/au/org/ala/ecodata/ProjectService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ProjectService.groovy
@@ -1123,7 +1123,7 @@ class ProjectService {
         results?.documents?.collect{
             def data = documentService.readJsonDocument(it)
             StatusChange doc
-            if (!data.error) {
+            if (data && !data.error) {
                 String approvedBy = data.approvedBy
                 if (lookupUserDetails) {
                     approvedBy = userService.lookupUserDetails(data.approvedBy)?.displayName ?: 'Unknown'


### PR DESCRIPTION
…system api #1233

This one was causing downloads that include any items from the MERI Plan section to fail in staging.