### PR TITLE
Use schema from investment priority branch for #1243

### DIFF
--- a/grails-app/domain/au/org/ala/ecodata/InvestmentPriority.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/InvestmentPriority.groovy
@@ -1,0 +1,60 @@
+package au.org.ala.ecodata
+
+import org.bson.types.ObjectId
+import org.springframework.validation.Errors
+
+/**
+ * An Investment Priority (also referred to as an Asset in older MERIT programs) is a Species/TEC/etc that
+ * programs are funded to work on.  MERIT projects will have targeted investment priorities selected from
+ * the set of investment priorities defined for the program.
+ */
+class InvestmentPriority {
+
+    ObjectId id
+
+    String investmentPriorityId
+    String status = Status.ACTIVE
+
+    /** Identifies the type of investment priority */
+    String type
+
+    /** Identifies the investment priority */
+    String name
+
+    /** The hub that defines / uses this Investment priority. */
+    String hubId
+
+    String description
+
+    /** Categories are used to group investment priorities together */
+    List categories
+
+    /** The management units in which this priority occurs */
+    List managementUnits
+
+    Date dateCreated
+    Date lastUpdated
+
+    def beforeValidate() {
+        if (investmentPriorityId == null) {
+            investmentPriorityId = Identifiers.getNew(true, "")
+        }
+    }
+
+    static mapping = {
+        index (['name':1, 'status':1, 'categories':1], [unique: true])
+        investmentPriorityId index:true
+        categories index: true
+    }
+
+    static constraints = {
+        description nullable: true
+        type nullable: true
+        name blank: false, unique: ['status']
+        hubId nullable: true, validator: { String hubId, InvestmentPriority investmentPriority, Errors errors ->
+            GormMongoUtil.validateWriteOnceProperty(investmentPriority, 'investmentPriorityId', 'hubId', errors)
+        }
+    }
+
+
+}

--- a/grails-app/domain/au/org/ala/ecodata/MeriPlan.groovy
+++ b/grails-app/domain/au/org/ala/ecodata/MeriPlan.groovy
@@ -204,7 +204,6 @@ class MeriPlan {
 
     List <String> getInvestmentPriorities() {
         List assets = []
-        assets.addAll(details.objectives.rows1?.collect{it.assets}?:[])
         assets.addAll(details.assets?.collect{it.description}?:[])
         assets.addAll(details.outcomes?.primaryOutcome?.assets?:[])
         assets.addAll(details.outcomes?.secondaryOutcomes?.collect({it.assets})?:[])

--- a/src/main/groovy/au/org/ala/ecodata/graphql/config/GraphQLConfig.groovy
+++ b/src/main/groovy/au/org/ala/ecodata/graphql/config/GraphQLConfig.groovy
@@ -187,6 +187,12 @@ class GraphQLConfig {
                 [(site.siteId): site]
             })
         })
+
+        registry.forTypePair(String, InvestmentPriority).withName("assets").registerMappedBatchLoader((investmentPriorityIds, env) -> {
+
+
+            Mono.just(investmentPriorityIds.collectEntries {[(it):new InvestmentPriority(name:it)] })
+        })
     }
 
     /** Here we transform the schema to add descriptions from the DataDescription collection. */

--- a/src/main/groovy/au/org/ala/ecodata/graphql/controller/ProjectQueryController.groovy
+++ b/src/main/groovy/au/org/ala/ecodata/graphql/controller/ProjectQueryController.groovy
@@ -314,6 +314,28 @@ class ProjectQueryController implements DataBinder {
         dataLoader.load(outputTarget.scoreId)
     }
 
+    @SchemaMapping(typeName = "ProjectOutcome", field = "assets")
+    CompletableFuture<List<InvestmentPriority>> assets(ProjectOutcome projectOutcome, DataLoader<String, InvestmentPriority> assets) {
+
+        List<CompletableFuture<InvestmentPriority>> futures = projectOutcome.assets.collect { String asset ->
+            assets.load(asset)
+        }
+
+        (CompletableFuture<List<InvestmentPriority>>)CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply{futures.collect{it.join()}}
+    }
+
+    @SchemaMapping(typeName = "MeriPlan", field = "investmentPriorities")
+    CompletableFuture<List<InvestmentPriority>> investmentPriorities(MeriPlan meriPlan, DataLoader<String, InvestmentPriority> assets) {
+
+        List<CompletableFuture<InvestmentPriority>> futures = meriPlan.investmentPriorities.collect { String asset ->
+            assets.load(asset)
+        }
+
+        (CompletableFuture<List<InvestmentPriority>>)CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply{futures.collect{it.join()}}
+    }
+
     @SchemaMapping(typeName = "DeliveredAgainstTarget", field = "targetMeasure")
     CompletableFuture<TargetMeasure> targetMeasure(DeliveredAgainstTarget deliveredAgainstTarget, DataLoader<String, TargetMeasure> dataLoader) {
         dataLoader.load(deliveredAgainstTarget.scoreId)
@@ -391,5 +413,6 @@ class ProjectQueryController implements DataBinder {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                 .thenApply{futures.collect{it.join()}}
     }
+
 
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -152,7 +152,7 @@ type MeriPlan {
 
     supportedPriorityPlaces: [String]
     "Environmental assets the Project is investing in protected"
-    investmentPriorities: [String]
+    investmentPriorities: [InvestmentPriority]
     "Project specific outcomes that are planned to be achieved in the medium term (3-5 years)"
     midTermOutcomes: [ProjectOutcome]
     "Measurable targets the Project plans to achieve"
@@ -444,9 +444,16 @@ type IntersectionArea {
     overlapM2: Float
 }
 
+type InvestmentPriority {
+    name: String
+    investmentPriorityId: String
+    categories: [String]
+    type: String
+}
+
 type ProjectOutcome {
     "Description"
-    assets: [String]
+    assets: [InvestmentPriority]
     "Description"
     code: String
     "Description"


### PR DESCRIPTION
This change is to align the production GraphQL schema with the future schema after the investment priorities branch is merged.  This is needed as the team using the API may not have resources after the time the branch will be deployed and their system was developed against staging which had that branch deployed.