### PR TITLE
#1270 Prevent measurementValue in top-level DwC export

### DIFF
--- a/grails-app/services/au/org/ala/ecodata/RecordService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/RecordService.groovy
@@ -1617,7 +1617,7 @@ class RecordService {
     }
 
     Map addUnlistedAttributesToResult(Map record, Map<String, Map> result) {
-        List ignoreAttributes = ["multimedia", "measurementsOrFacts"]
+        List ignoreAttributes = ["multimedia", "measurementsOrFacts", "measurementValue"]
         if (record.occurrenceID) {
             copyMissingAttributes(record, result[DWC_OCCURRENCE], ignoreAttributes)
         }

--- a/src/test/groovy/au/org/ala/ecodata/RecordServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/RecordServiceSpec.groovy
@@ -97,5 +97,25 @@ class RecordServiceSpec extends MongoSpec implements ServiceUnitTest<RecordServi
         null               | null                 | service.SCIENTIFIC_NAME_COMMON_NAME       | ''
     }
 
+    void "addUnlistedAttributesToResult should not copy measurementValue onto Occurrence"() {
+        given:
+        Map record = [
+                occurrenceID     : "occ-1",
+                scientificName   : "Anura",
+                measurementValue : "1.0",
+                measurementsOrFacts: [[measurementValue: "1.0", measurementType: "distance"]],
+                customField      : "keep-me"
+        ]
+        Map result = [(RecordService.DWC_OCCURRENCE): [occurrenceID: "occ-1", scientificName: "Anura"]].withDefault { [:] }
+
+        when:
+        service.addUnlistedAttributesToResult(record, result)
+
+        then:
+        result[RecordService.DWC_OCCURRENCE].customField == "keep-me"
+        !result[RecordService.DWC_OCCURRENCE].containsKey("measurementValue")
+        !result[RecordService.DWC_OCCURRENCE].containsKey("measurementsOrFacts")
+    }
+
 }
 


### PR DESCRIPTION
`measurementValue` should only be emitted via the measurementsOrFacts structure, not as a top-level attribute in DwC archives