### PR TITLE
Feature/issue1284

### DIFF
--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -2035,4 +2035,4 @@ paratoo.defaultPlotLayoutViewModels = [
                 ]
         ]
 paratoo.species.specialCases = ["Other", "N/A"]
-paratoo.api.writeScope = "paratoo_api_write"
+paratoo.api.writeScope = "ecodata/write_paratoo_api_test"

--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -2035,3 +2035,4 @@ paratoo.defaultPlotLayoutViewModels = [
                 ]
         ]
 paratoo.species.specialCases = ["Other", "N/A"]
+paratoo.api.writeScope = "paratoo_api_write"

--- a/grails-app/controllers/au/org/ala/ecodata/ParatooController.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/ParatooController.groovy
@@ -29,7 +29,7 @@ import javax.ws.rs.Path
 
 // Requiring these scopes will guarantee we can get a valid userId out of the process.
 @Slf4j
-@au.ala.org.ws.security.RequireApiKey(scopes = ["profile", "openid"])
+@au.ala.org.ws.security.RequireApiKey(scopes = ["profile", "openid"], scopesFromProperty = "paratoo.api.writeScope", anyScope = true)
 @OpenAPIDefinition(
         info = @Info(
                 title = "Ecodata APIs",

--- a/grails-app/controllers/au/org/ala/ecodata/ParatooInterceptor.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/ParatooInterceptor.groovy
@@ -2,11 +2,13 @@ package au.org.ala.ecodata
 
 import au.org.ala.ecodata.paratoo.ParatooInvocationContext
 import au.org.ala.web.AuthService
+import grails.core.GrailsApplication
 import org.apache.http.HttpStatus
 
 class ParatooInterceptor {
 
     AuthService authService
+    GrailsApplication grailsApplication
 
     int order = 110 // Runs after the AuditInterceptor which sets the user in the UserService
     ParatooInterceptor() {
@@ -29,7 +31,12 @@ class ParatooInterceptor {
             operationType = request.method == "GET" ? Permission.READ : Permission.WRITE
         }
 
-        ParatooInvocationContext.setCurrent(new ParatooInvocationContext(userId: authService.userId, operationType: operationType, apiVersion: apiVersion))
+        // The Monitor/Paratoo application has a use case where it needs to call the API on behalf of a user,
+        // but the user is not actually logged in.  This is implemented by a JWT with a scope allowing
+        // access to write to the paratoo API without a direct user context.
+        String scope = grailsApplication.config.getProperty('paratoo.api.writeScope')
+        boolean isSystemUser = request.isUserInRole(scope)
+        ParatooInvocationContext.setCurrent(new ParatooInvocationContext(userId: authService.userId, isSystemUser: isSystemUser, operationType: operationType, apiVersion: apiVersion))
         true
     }
 

--- a/grails-app/controllers/au/org/ala/ecodata/PreAuthoriseInterceptor.groovy
+++ b/grails-app/controllers/au/org/ala/ecodata/PreAuthoriseInterceptor.groovy
@@ -38,14 +38,6 @@ class PreAuthoriseInterceptor {
         if (pa?.basicAuth()) {
             def user = userService.setUser()
             request.userId = user?.userId
-            if (user == null) {
-                UserProfile profile = authService.delegateService.getUserProfile()
-                if (profile instanceof AlaM2MUserProfile) {
-                    // get client id of the M2M user
-                    String userId = request.userId = profile.getUserId()
-                    userService.setCurrentUser(userId)
-                }
-            }
 
             if (permissionService.isUserAlaAdmin(request.userId)) {
                 /* Don't enforce check for ALA admin.*/

--- a/grails-app/services/au/org/ala/ecodata/ParatooService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/ParatooService.groovy
@@ -475,6 +475,10 @@ class ParatooService {
     }
 
     boolean protocolCheck(String userId, String projectId, String protocolId, Permission operationType) {
+
+        if (ParatooInvocationContext.getCurrent()?.isSystemUser) {
+            return true
+        }
         UserPermission permission = UserPermission.findByUserIdAndEntityIdAndEntityTypeAndStatusNotEqualAndAccessLevelNotEqual(userId, projectId, Project.class.name, Status.DELETED, AccessLevel.starred)
         if (!permission) {
             log.warn("User ${userId} has no permissions for project ${projectId}")

--- a/grails-app/services/au/org/ala/ecodata/UserService.groovy
+++ b/grails-app/services/au/org/ala/ecodata/UserService.groovy
@@ -1,8 +1,10 @@
 package au.org.ala.ecodata
 
 import au.org.ala.web.AuthService
+import au.org.ala.ws.security.profile.AlaM2MUserProfile
 import grails.core.GrailsApplication
 import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.pac4j.core.profile.UserProfile
 
 import javax.servlet.http.HttpServletRequest
 
@@ -201,6 +203,17 @@ class UserService {
         // If the OIDC provider is CAS, authService.getUser() will return the clientId, if it's Cognito, it will return null.
         if (!userId) {
             userId = authService.getUserId()
+
+            if (!userId) {
+                UserProfile profile = authService.delegateService.getUserProfile()
+                if (profile instanceof AlaM2MUserProfile) {
+                    // get client id of the M2M user as the userId for the request.
+                    // This is the case for the DAFF API M2M token as well as the Monitor core M2M token.
+                    // Although they have an AlaM2MUserProfile, MERIT and BioCollect also use a delegate user
+                    // so will have been set in checkForDelegatedUserId() above.
+                    userId = request.userId = profile.getUserId()
+                }
+            }
         }
         if (userId) {
             if (log.isDebugEnabled()) {

--- a/src/main/groovy/au/org/ala/ecodata/paratoo/ParatooInvocationContext.groovy
+++ b/src/main/groovy/au/org/ala/ecodata/paratoo/ParatooInvocationContext.groovy
@@ -17,6 +17,7 @@ class ParatooInvocationContext {
     }
 
     static final String API_VERSION_1 = "v1"
+    boolean isSystemUser = false
     String userId
     String apiVersion
     /**

--- a/src/test/groovy/au/org/ala/ecodata/PreAuthoriseInterceptorSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/PreAuthoriseInterceptorSpec.groovy
@@ -92,38 +92,6 @@ class PreAuthoriseInterceptorSpec extends Specification implements InterceptorUn
         "annotatedPublicAction" | 200 | true
         "publicAction" | 200 | true
     }
-
-    void "interceptor should allow access using M2M token where required and pass when permission is granted"() {
-        given:
-        // need to do this because grailsApplication.controllerClasses is empty in the filter when run from the unit test
-        // unless we manually add the dummy controller class used in this test
-        grailsApplication.addArtefact("Controller", AnnotatedMethodController)
-        AnnotatedMethodController controller = new AnnotatedMethodController()
-
-        params.id = "abc"
-        userService.setUser() >> null
-        delegateService.getUserProfile() >> new AlaM2MUserProfile("m2mUser", "issuer", [])
-        hubService.findByUrlPath(params.id) >> [hubId: "hub1", name: "Test Hub", urlPath: params.id]
-        permissionService.isUserAlaAdmin(_) >> false
-        permissionService.checkPermission("readOnly", "hub1", Hub.class.name, "m2mUser") >> [error: '', status: 403]
-
-        when:
-
-        request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, 'annotatedMethod')
-        request.setAttribute(GrailsApplicationAttributes.ACTION_NAME_ATTRIBUTE, action)
-        withRequest(controller: "annotatedMethod", action: action)
-        def result = interceptor.before()
-
-        then:
-        response.status == statusCode
-        result == before
-
-        where:
-        action | statusCode | before
-        "securedAction" | 200 | true
-        "annotatedPublicAction" | 200 | true
-        "publicAction" | 200 | true
-    }
 }
 
 

--- a/src/test/groovy/au/org/ala/ecodata/UserServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/UserServiceSpec.groovy
@@ -1,6 +1,8 @@
 package au.org.ala.ecodata
 
 import au.org.ala.web.AuthService
+import au.org.ala.web.IAuthService
+import au.org.ala.web.Pac4jAuthService
 import au.org.ala.ws.security.profile.AlaM2MUserProfile
 import grails.test.mongodb.MongoSpec
 import grails.testing.services.ServiceUnitTest
@@ -16,6 +18,7 @@ class UserServiceSpec extends MongoSpec implements ServiceUnitTest<UserService>,
 
     WebService webService = Mock(WebService)
     AuthService authService = Mock(AuthService)
+    Pac4jAuthService delegateService = Mock(Pac4jAuthService)
     Config pack4jConfig
 
     def user
@@ -33,6 +36,7 @@ class UserServiceSpec extends MongoSpec implements ServiceUnitTest<UserService>,
         new Hub(hubId:'h2', urlPath:'hub2').save(flush:true, failOnError:true)
         service.webService = webService
         service.authService = authService
+        service.authService.delegateService >> delegateService
     }
 
     def cleanup() {
@@ -193,8 +197,22 @@ class UserServiceSpec extends MongoSpec implements ServiceUnitTest<UserService>,
         1 * authService.getUserId() >> null
         0 * authService.getUserDetailsById(_)
         UserService.currentUser() == null
+    }
 
+    void "If the request has a non ALA M2M token, the userId will not be read from the header, but will be assigned to the client ID of the token"() {
+        setup:
+        AuditInterceptor.httpRequestHeaderForUserId = 'userId'
+        request.addUserRole("ecodata/write_paratoo_api_test")
 
+        when:
+        request.addHeader('userId', user.userId)
+        service.setUser()
+
+        then:
+        1 * delegateService.getUserProfile() >> new AlaM2MUserProfile("m2mUser", "issuer", [])
+        1 * authService.getUserId() >> null
+        0 * authService.getUserDetailsById(_)
+        UserService.currentUser().userId == "m2mUser"
     }
 
 


### PR DESCRIPTION
Can you please review this approach Temi but maybe hold off on any merge until we hear back from the Monitor team?
I've moved a bit of code that handles M2M tokens from PreAuthorise into the UserService to make it usable in the Monitor case - the "act on behalf of a user" is still locked behind the ecodata/read scope for now.